### PR TITLE
Add semantic memory retrieval with query/document embedding split

### DIFF
--- a/demo/cli.py
+++ b/demo/cli.py
@@ -15,6 +15,16 @@ def cmd_store(args):
     print(f"Stored [{record_id[:8]}]: {args.content}")
 
 
+def cmd_query(args):
+    store = SemanticStore()
+    results = store.retrieve(args.query, top_k=args.top_k)
+    if not results:
+        print("No results found.")
+        return
+    for rank, (record, score) in enumerate(results, 1):
+        print(f"  {rank}. [{score:.4f}] {record.content}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Agentic Memory CLI")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -22,10 +32,16 @@ def main():
     store_p = sub.add_parser("store", help="Store a new memory")
     store_p.add_argument("content", type=str, help="Text content to store")
 
+    query_p = sub.add_parser("query", help="Search memories by meaning")
+    query_p.add_argument("query", type=str, help="Natural language query")
+    query_p.add_argument("-k", "--top-k", type=int, default=5, help="Number of results")
+
     args = parser.parse_args()
 
     if args.command == "store":
         cmd_store(args)
+    elif args.command == "query":
+        cmd_query(args)
 
 
 if __name__ == "__main__":

--- a/stores/base.py
+++ b/stores/base.py
@@ -15,3 +15,8 @@ class BaseStore(ABC):
     def get_by_id(self, record_id: str) -> MemoryRecord | None:
         """Fetch a single record by id. Returns None if not found."""
         ...
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> list[tuple[MemoryRecord, float]]:
+        """Semantic search. Returns (record, similarity_score) pairs, highest first."""
+        ...

--- a/stores/semantic_store.py
+++ b/stores/semantic_store.py
@@ -12,7 +12,10 @@ class SemanticStore(BaseStore):
 
     def __init__(self):
         client = chromadb.PersistentClient(path=CHROMA_DB_PATH)
-        self._collection = client.get_or_create_collection(name="semantic_memories")
+        self._collection = client.get_or_create_collection(
+            name="semantic_memories",
+            metadata={"hnsw:space": "cosine"},
+        )
         self._embedder = GeminiEmbedder()
 
     # ── write ──────────────────────────────────────────────────────────────
@@ -40,6 +43,24 @@ class SemanticStore(BaseStore):
             return None
         return self._from_result(result, 0)
 
+    def retrieve(self, query: str, top_k: int = 5) -> list[tuple[SemanticMemory, float]]:
+        query_embedding = self._embedder.embed_query(query)
+        result = self._collection.query(
+            query_embeddings=[query_embedding],
+            n_results=top_k,
+            include=["embeddings", "documents", "metadatas", "distances"],
+        )
+        if not result["ids"] or not result["ids"][0]:
+            return []
+
+        pairs = []
+        for i in range(len(result["ids"][0])):
+            record = self._from_query_result(result, i)
+            # ChromaDB cosine distance = 1 - similarity
+            similarity = 1.0 - result["distances"][0][i]
+            pairs.append((record, similarity))
+        return pairs
+
     # ── serialisation helpers ──────────────────────────────────────────────
     # ChromaDB metadata must be flat (str/int/float/bool only — no nested dicts).
 
@@ -55,11 +76,27 @@ class SemanticStore(BaseStore):
         }
 
     def _from_result(self, result: dict, index: int) -> SemanticMemory:
+        """Deserialise from .get() result (flat lists)."""
         meta = result["metadatas"][index]
         return SemanticMemory(
             content=result["documents"][index],
             id=result["ids"][index],
             embedding=result["embeddings"][index],
+            created_at=datetime.fromisoformat(meta["created_at"]),
+            importance=float(meta["importance"]),
+            source=meta["source"] or None,
+            category=meta["category"],
+            confidence=float(meta["confidence"]),
+            modality=meta["modality"],
+        )
+
+    def _from_query_result(self, result: dict, index: int) -> SemanticMemory:
+        """Deserialise from .query() result (nested lists — one list per query)."""
+        meta = result["metadatas"][0][index]
+        return SemanticMemory(
+            content=result["documents"][0][index],
+            id=result["ids"][0][index],
+            embedding=result["embeddings"][0][index],
             created_at=datetime.fromisoformat(meta["created_at"]),
             importance=float(meta["importance"]),
             source=meta["source"] or None,

--- a/utils/embeddings.py
+++ b/utils/embeddings.py
@@ -9,19 +9,31 @@ class GeminiEmbedder:
 
     def __init__(self):
         self._client = genai.Client(api_key=GEMINI_API_KEY)
-        self._config = types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIMENSIONS)
+        self._doc_config = types.EmbedContentConfig(
+            output_dimensionality=EMBEDDING_DIMENSIONS,
+            task_type="RETRIEVAL_DOCUMENT",
+        )
+        self._query_config = types.EmbedContentConfig(
+            output_dimensionality=EMBEDDING_DIMENSIONS,
+            task_type="RETRIEVAL_QUERY",
+        )
 
-    def _embed(self, contents: list) -> list[list[float]]:
+    def _embed(self, contents: list, config: types.EmbedContentConfig | None = None) -> list[list[float]]:
         """Core call — returns one vector per item in contents."""
         result = self._client.models.embed_content(
             model=EMBEDDING_MODEL,
             contents=contents,
-            config=self._config,
+            config=config or self._doc_config,
         )
         return [e.values for e in result.embeddings]
 
     def embed_text(self, text: str) -> list[float]:
-        return self._embed([text])[0]
+        """Embed text for storage (RETRIEVAL_DOCUMENT task type)."""
+        return self._embed([text], self._doc_config)[0]
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed text for querying (RETRIEVAL_QUERY task type)."""
+        return self._embed([text], self._query_config)[0]
 
     def embed_image(self, image_bytes: bytes, mime_type: str = "image/png") -> list[float]:
         part = types.Part.from_bytes(data=image_bytes, mime_type=mime_type)


### PR DESCRIPTION
## What this does

Adds the **read path** to the semantic memory store — given a natural language query, find the most relevant stored facts by meaning.

## Why

The write path (initial commit) could store facts but had no way to get them back by *meaning*. This is the core operation the memory system exists for: store knowledge, retrieve it later when relevant context is needed.

## Architecture

```mermaid
sequenceDiagram
    participant C as CLI (query command)
    participant S as SemanticStore
    participant E as GeminiEmbedder
    participant G as Gemini API
    participant D as ChromaDB

    C->>S: retrieve("Who created Python?", top_k=5)
    S->>E: embed_query(text)
    Note over E: uses RETRIEVAL_QUERY task type
    E->>G: embed_content(text, task=RETRIEVAL_QUERY, 768 dims)
    G-->>E: query vector
    E-->>S: query vector
    S->>D: .query(vector, n_results=5)
    D-->>S: ids, documents, embeddings, distances
    Note over S: similarity = 1.0 - cosine_distance
    S-->>C: [(SemanticMemory, score), ...]
```

### Query vs Document Embedding

```mermaid
graph LR
    subgraph "Store Path"
        DOC["'Python was created by Guido'"]
        DOC -->|embed_text| DCONF["RETRIEVAL_DOCUMENT"]
        DCONF --> DVEC["document vector"]
        DVEC --> DB[(ChromaDB)]
    end

    subgraph "Query Path"
        Q["'Who created Python?'"]
        Q -->|embed_query| QCONF["RETRIEVAL_QUERY"]
        QCONF --> QVEC["query vector"]
        QVEC --> SEARCH["cosine similarity search"]
        DB --> SEARCH
        SEARCH --> RESULTS["ranked results"]
    end
```

Gemini Embedding 2 uses different internal logic for queries vs documents. A query like "Who created Python?" is an *information need* — short, question-shaped. A document like "Python was created by Guido van Rossum" is a *knowledge statement*. Embedding them with the correct task type gives measurably better retrieval accuracy than using a single generic embedding for both.

## Key decisions

**Cosine distance metric on ChromaDB.** Changed from the default L2 to cosine distance. Cosine measures the angle between vectors (semantic direction) rather than magnitude. Two facts of different lengths but similar meaning score high. This is the standard for text retrieval.

**Similarity = 1 - distance.** ChromaDB returns cosine *distance* (0 = identical, 2 = opposite). We convert to similarity (1.0 = identical, -1.0 = opposite) because it's more intuitive — higher means more relevant.

**Separate `_from_query_result` deserializer.** ChromaDB `.get()` returns flat lists, `.query()` returns nested lists (one list per query batch). Rather than adding branching logic to one method, there are two clean deserializers.

## Test results

Stored three facts, queried with three different questions:

```
> query "Who created Python?"
  1. [0.8993] Python was created by Guido van Rossum
  2. [0.5497] The capital of France is Paris
  3. [0.5448] FastAPI uses Starlette under the hood

> query "What is the capital of France?"
  1. [0.9187] The capital of France is Paris
  2. [0.5667] FastAPI uses Starlette under the hood
  3. [0.5568] Python was created by Guido van Rossum

> query "What web framework is built on Starlette?"
  1. [0.7895] FastAPI uses Starlette under the hood
  2. [0.5810] Python was created by Guido van Rossum
  3. [0.5126] The capital of France is Paris
```

All three return the correct fact first. The gap between the top result and second place ranges from 0.21 to 0.35 — strong separation.

## Files changed

- `utils/embeddings.py` — split into `embed_text()` (RETRIEVAL_DOCUMENT) and `embed_query()` (RETRIEVAL_QUERY)
- `stores/base.py` — added `retrieve()` to abstract interface
- `stores/semantic_store.py` — implemented `retrieve()`, added cosine metric
- `demo/cli.py` — added `query` command with `-k` flag