### PR TITLE
Add weighted ranking function for memory retrieval

### DIFF
--- a/retrieval/ranking.py
+++ b/retrieval/ranking.py
@@ -28,22 +28,32 @@ def rank_results(
 
     now = now or datetime.now(timezone.utc)
 
-    # ── normalise recency to 0-1 ────────────────────────────────────────
+    # ── normalise recency to 0-1 (min-max over candidate set) ───────────
     # Use last_accessed_at if set, otherwise created_at.
-    # The most recent memory gets 1.0, the oldest gets 0.0.
-    # If all timestamps are identical, everything gets 1.0.
+    # Newest candidate gets 1.0, oldest gets 0.0.
+    # Single candidate or identical timestamps → all get 1.0.
 
     def _timestamp(record: MemoryRecord) -> datetime:
-        return record.last_accessed_at or record.created_at
+        ts = record.last_accessed_at or record.created_at
+        # Normalise naive timestamps to UTC so subtraction never raises
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return ts
+
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
 
     ages = [(now - _timestamp(r)).total_seconds() for r, _ in results]
+    min_age = min(ages)
     max_age = max(ages)
+    span = max_age - min_age
 
-    if max_age == 0:
+    if span == 0:
+        # Single result, or all timestamps identical — no penalty
         recency_scores = [1.0] * len(results)
     else:
-        # age 0 → recency 1.0, max_age → recency 0.0
-        recency_scores = [1.0 - (age / max_age) for age in ages]
+        # min_age → 1.0 (newest), max_age → 0.0 (oldest)
+        recency_scores = [1.0 - (age - min_age) / span for age in ages]
 
     # ── compute final scores ────────────────────────────────────────────
 

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -69,6 +69,52 @@ def test_relevance_dominates():
     print(f"         strong: {ranked[0].final_score:.4f}  weak: {ranked[1].final_score:.4f}")
 
 
+def test_single_candidate():
+    """P1 fix: a single result should get recency 1.0, not 0.0."""
+    now = datetime.now(timezone.utc)
+    record = make_record("Only fact", created_at=now - timedelta(days=10))
+    results = [(record, 0.85)]
+
+    ranked = rank_results(results, relevance_weight=0.4, recency_weight=0.3, importance_weight=0.3, now=now)
+    assert ranked[0].recency_score == 1.0, (
+        f"Single candidate should get recency 1.0, got {ranked[0].recency_score}"
+    )
+    print(f"  PASS  single candidate → recency 1.0 (not penalized)")
+    print(f"         score: {ranked[0].final_score:.4f}  recency: {ranked[0].recency_score:.4f}")
+
+
+def test_all_old_candidates():
+    """P1 fix: when all candidates are old, newest still gets 1.0, oldest gets 0.0."""
+    now = datetime.now(timezone.utc)
+    oldest = make_record("Fact A", created_at=now - timedelta(days=365))
+    middle = make_record("Fact B", created_at=now - timedelta(days=200))
+    newest = make_record("Fact C", created_at=now - timedelta(days=100))
+
+    results = [(oldest, 0.80), (middle, 0.80), (newest, 0.80)]
+    ranked = rank_results(results, relevance_weight=0.2, recency_weight=0.6, importance_weight=0.2, now=now)
+
+    # Find each by identity
+    scores = {id(r.record): r for r in ranked}
+    assert scores[id(newest)].recency_score == 1.0, "Newest of old candidates should still get 1.0"
+    assert scores[id(oldest)].recency_score == 0.0, "Oldest should get 0.0"
+    assert 0.0 < scores[id(middle)].recency_score < 1.0, "Middle should be between 0 and 1"
+    print(f"  PASS  all-old candidates → min-max normalization works")
+    print(f"         newest: {scores[id(newest)].recency_score:.4f}  "
+          f"middle: {scores[id(middle)].recency_score:.4f}  "
+          f"oldest: {scores[id(oldest)].recency_score:.4f}")
+
+
+def test_naive_timestamps():
+    """P2 fix: naive datetimes (no tzinfo) should not raise TypeError."""
+    naive_now = datetime(2026, 3, 22, 12, 0, 0)  # no timezone
+    record = make_record("Fact", created_at=datetime(2026, 3, 20, 12, 0, 0))
+
+    results = [(record, 0.85)]
+    ranked = rank_results(results, now=naive_now)
+    assert ranked[0].recency_score == 1.0
+    print(f"  PASS  naive timestamps → no TypeError, handled gracefully")
+
+
 def test_empty():
     ranked = rank_results([])
     assert ranked == []
@@ -80,5 +126,8 @@ if __name__ == "__main__":
     test_recency_weight()
     test_importance_weight()
     test_relevance_dominates()
+    test_single_candidate()
+    test_all_old_candidates()
+    test_naive_timestamps()
     test_empty()
     print("\nAll tests passed.")


### PR DESCRIPTION
## What this does

Adds a ranking layer that re-scores raw ChromaDB results using a weighted combination of three signals, so the retriever can prioritize what matters most for the current query.

## Why

ChromaDB returns results ranked by cosine similarity alone. But "most semantically similar" isn't always "most useful." A fact stored 30 days ago with a 0.91 similarity score might be less useful than one stored 5 minutes ago with a 0.89 score — the recent one is more likely to be contextually relevant.

The DeepMind paper's memory model has implicit recency bias (recent episodic memories are easier to recall) and importance weighting (emotionally significant memories resist decay). This ranking function makes those signals explicit and tunable.

## Architecture

```mermaid
graph LR
    subgraph "Current: ChromaDB only"
        Q1["query vector"] --> CS["cosine similarity"]
        CS --> R1["ranked by similarity only"]
    end

    subgraph "New: Weighted ranking"
        Q2["query vector"] --> CS2["cosine similarity"]
        CS2 --> REL["relevance signal"]
        TS["created_at / last_accessed_at"] --> REC["recency signal"]
        IMP["importance field"] --> IMP2["importance signal"]
        REL --> RANK["rank_results()"]
        REC --> RANK
        IMP2 --> RANK
        RANK --> R2["ranked by weighted score"]
    end
```

### Scoring formula

```
final_score = relevance * w_r + recency * w_rec + importance * w_imp

default weights: 0.4 / 0.3 / 0.3
```

### Recency normalization

```mermaid
graph TB
    subgraph "Recency Normalization"
        A["ages = now - timestamp for each result"] --> B["max_age = max(ages)"]
        B --> C["recency = 1.0 - age/max_age"]
        C --> D["newest → 1.0, oldest → 0.0"]
    end
```

Uses `last_accessed_at` when set, falls back to `created_at`. Normalization is relative to the result set — the oldest result always gets 0.0, the newest always gets 1.0. If all timestamps are identical, everything gets 1.0 (no recency penalty).

## Key decisions

**Relative normalization, not absolute.** Recency is normalized within the result set, not against some fixed time window. This means the ranking behaves consistently whether the memory store has data spanning 5 minutes or 5 years. Tradeoff: two results 1 second apart in a 1-hour-old store get almost the same recency score, while in a 1-year-old store the same 1-second gap would be invisible. This is the right behavior — recency only matters relative to what else was found.

**`RankedResult` dataclass exposes all signals.** The caller gets the final score plus each individual component (`raw_similarity`, `recency_score`, `importance_score`). This makes debugging straightforward and enables future metacognitive monitoring — the system can explain *why* a memory ranked where it did.

**Weights are caller-tunable.** The default 0.4/0.3/0.3 split is a starting point. Different query types may want different profiles — a "what happened recently?" query should crank recency, while a "what do I know about X?" query should crank relevance. The retriever (next step) will choose weights based on query intent.

## Test results

```
Ranking tests:

  PASS  high recency weight → newer wins
         new: 0.8799  old: 0.2800
  PASS  zero recency weight → tied scores
         both: 0.7000
  PASS  high importance weight → important record wins
         high: 0.9100  low: 0.4900
  PASS  high relevance weight → best match wins despite being old and low importance
         strong: 0.6800  weak: 0.6500
  PASS  empty input → empty output

All tests passed.
```

The recency test is the key one: two records with identical content, identical similarity (0.90), identical importance (0.5) — one created 30 days ago, one 5 minutes ago. With recency weight at 0.6, the newer one scores 0.88 vs 0.28. With recency weight at 0.0, they tie at 0.70. Weight swapping correctly flips the ranking.

## Files changed

- `retrieval/ranking.py` — `rank_results()` function + `RankedResult` dataclass
- `tests/test_ranking.py` — 4 test cases covering recency, importance, relevance dominance, and empty input