### PR TITLE
Add session and temporal episodic queries for issue #7

### DIFF
--- a/stores/episodic_store.py
+++ b/stores/episodic_store.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timezone
+from heapq import nlargest
 from pathlib import Path
 
 import chromadb
@@ -104,19 +105,21 @@ class EpisodicStore(BaseStore):
 
     def get_by_session(self, session_id: str) -> list[EpisodicMemory]:
         """Return all episodic records for a session, ordered by turn then created_at."""
-        records = [record for record in self._all_records() if record.session_id == session_id]
+        records = self._all_records(
+            where={"session_id": session_id},
+            include_embeddings=False,
+        )
         return sorted(records, key=self._session_sort_key)
 
     def get_recent(self, n: int) -> list[EpisodicMemory]:
         """Return the most recent episodic records across sessions, newest first."""
         if n <= 0:
             return []
-        records = sorted(
-            self._all_records(),
+        return nlargest(
+            n,
+            self._all_records(include_embeddings=False),
             key=lambda record: self._as_utc(record.created_at),
-            reverse=True,
         )
-        return records[:n]
 
     def get_by_time_range(
         self,
@@ -135,7 +138,7 @@ class EpisodicStore(BaseStore):
 
         records = [
             record
-            for record in self._all_records()
+            for record in self._all_records(include_embeddings=False)
             if start_utc <= self._as_utc(record.created_at) <= end_utc
         ]
         return sorted(records, key=lambda record: self._as_utc(record.created_at))
@@ -216,9 +219,19 @@ class EpisodicStore(BaseStore):
             "source_mime_type": record.source_mime_type or "",
         }
 
-    def _all_records(self) -> list[EpisodicMemory]:
+    def _all_records(
+        self,
+        *,
+        where: dict | None = None,
+        include_embeddings: bool = True,
+    ) -> list[EpisodicMemory]:
+        include = ["documents", "metadatas"]
+        if include_embeddings:
+            include.insert(0, "embeddings")
+
         result = self._collection.get(
-            include=["embeddings", "documents", "metadatas"],
+            where=where,
+            include=include,
         )
         if not result["ids"]:
             return []
@@ -264,10 +277,11 @@ class EpisodicStore(BaseStore):
         )
 
     def _from_result(self, result: dict, index: int) -> EpisodicMemory:
+        embeddings = result.get("embeddings")
         return self._build_record(
             result["documents"][index],
             result["ids"][index],
-            result["embeddings"][index],
+            embeddings[index] if embeddings is not None else None,
             result["metadatas"][index],
         )
 

--- a/tests/test_episodic_store.py
+++ b/tests/test_episodic_store.py
@@ -181,9 +181,27 @@ def test_get_by_session_orders_by_turn_number_then_created_at():
 
 def test_get_by_session_filters_across_sessions():
     store, _ = fresh_setup()
-    store.store(EpisodicMemory(content="alpha event", session_id="session-alpha"))
-    store.store(EpisodicMemory(content="beta event", session_id="session-beta"))
-    store.store(EpisodicMemory(content="alpha follow-up", session_id="session-alpha"))
+    store.store(
+        EpisodicMemory(
+            content="alpha event",
+            session_id="session-alpha",
+            created_at=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    store.store(
+        EpisodicMemory(
+            content="beta event",
+            session_id="session-beta",
+            created_at=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+        )
+    )
+    store.store(
+        EpisodicMemory(
+            content="alpha follow-up",
+            session_id="session-alpha",
+            created_at=datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
+        )
+    )
 
     results = store.get_by_session("session-alpha")
 


### PR DESCRIPTION
## Summary

This PR implements the next slice of Step 4: direct session-based and time-based access for episodic memories.

The previous PR added the `EpisodicMemory` model and the `EpisodicStore` persistence layer. This PR builds on that by adding three non-semantic lookup methods that answer questions like:

- "Show me all memories from this conversation/session."
- "Show me the most recent episodes overall."
- "Show me only the episodes that happened between two timestamps."

These are direct episodic queries. They are not embedding search and they are not ranking-based retrieval.

Closes #7

## Why This PR Exists

Episodic memory is not only about semantic similarity. A system also needs to answer:

- what happened in session `X`
- what happened most recently
- what happened during a particular time window

Those queries should work the same way whether the episode is:

- text-backed
- image-backed
- audio-backed
- video-backed
- PDF-backed

That is the gap this PR fills.

## What Changed

### 1. Added `get_by_session(session_id)`

File: `stores/episodic_store.py`

This method returns only the episodic records whose `session_id` matches the requested session.

Ordering rule:

- first by `turn_number`
- then by `created_at`

Why this matters:

- it keeps a conversation/session in stable turn order
- if multiple records share the same turn number, timestamp breaks the tie
- records without a `turn_number` are placed after records that do have one

This gives predictable session playback behavior and sets up later session-aware features cleanly.

### 2. Added `get_recent(n)`

File: `stores/episodic_store.py`

This method returns the newest `n` episodic memories across all sessions.

Ordering rule:

- newest first by `created_at`

Why this matters:

- this gives a direct "recent episodes" view
- it does not depend on semantic similarity
- it works across modalities and sessions

### 3. Added `get_by_time_range(start, end)`

File: `stores/episodic_store.py`

This method returns episodic memories whose `created_at` falls inside the requested time window.

Time window rule:

- inclusive on both ends
- `start <= record.created_at <= end`

Sorting rule:

- chronological order by `created_at`

Validation rule:

- if `start > end`, the method raises `ValueError`

### 4. Added stable timezone handling

One subtle issue with time-range APIs is mixing:

- timezone-aware datetimes
- naive datetimes

This PR makes the behavior explicit:

- naive datetimes are treated as UTC
- aware datetimes are converted to UTC before comparison

That keeps comparisons deterministic in tests and avoids ambiguous local-time behavior.

### 5. Added internal helpers to support direct queries

Also in `stores/episodic_store.py`, this PR adds:

- `_all_records()` to load all episodic records from the collection
- `_session_sort_key()` to centralize session ordering
- `_as_utc()` to normalize datetimes before comparisons

These helpers keep the public query methods small and make the ordering rules easier to reason about.

## What This PR Does Not Do

This PR does not change embedding retrieval or retriever fan-out.

It does not add:

- semantic + episodic merged retrieval
- retriever methods like `query_recent()` or `query_time_range()`
- CLI commands
- benchmark harnesses

Those belong in later sub-issues.

## Query Semantics

### Session Query

```mermaid
flowchart TD
    A[Load all episodic records] --> B[Filter by session_id]
    B --> C[Sort by turn_number]
    C --> D[Break ties with created_at]
    D --> E[Return ordered session history]
```

### Recent Query

```mermaid
flowchart TD
    A[Load all episodic records] --> B[Normalize created_at to UTC]
    B --> C[Sort newest first]
    C --> D[Take top n]
    D --> E[Return recent episodes]
```

### Time Range Query

```mermaid
flowchart TD
    A[Input start and end] --> B[Normalize to UTC]
    B --> C{start <= end?}
    C -->|No| D[Raise ValueError]
    C -->|Yes| E[Load all episodic records]
    E --> F[Keep records inside inclusive window]
    F --> G[Sort chronologically]
    G --> H[Return matching episodes]
```

## Human-Level Behavior Examples

### Example 1: Replaying a session

If session `session-alpha` contains:

- turn 1 at 12:01
- turn 1 at 12:05
- turn 2 at 12:00

then `get_by_session("session-alpha")` returns:

1. turn 1 at 12:01
2. turn 1 at 12:05
3. turn 2 at 12:00

The point is to preserve turn structure first, then timestamp order within the same turn.

### Example 2: Asking for recent memory

If three episodes were created at:

- 12:00
- 12:10
- 12:20

then `get_recent(2)` returns the 12:20 and 12:10 records, in that order.

### Example 3: Inclusive time windows

If the requested window is:

- start: 12:00
- end: 12:15

then records at:

- 12:00 are included
- 12:10 are included
- 12:15 are included
- 11:55 are excluded
- 12:20 are excluded

## Files Changed

### `stores/episodic_store.py`

Added:

- `get_by_session(session_id)`
- `get_recent(n)`
- `get_by_time_range(start, end)`
- `_all_records()`
- `_session_sort_key()`
- `_as_utc()`

Net effect:

- the episodic store now supports direct session and temporal lookups in addition to embedding search

### `tests/test_episodic_store.py`

Added deterministic tests for:

- same-session ordering
- multi-session filtering
- newest-first recent queries
- inclusive time-range filtering
- naive datetime normalization to UTC
- mixed modality session queries
- empty results for direct query APIs

These tests sit on top of the earlier store/model tests and keep the new behavior fully offline.

## Test Coverage

### New tests added for this PR

- `test_get_by_session_orders_by_turn_number_then_created_at`
- `test_get_by_session_filters_across_sessions`
- `test_get_recent_returns_newest_first_across_sessions`
- `test_get_by_time_range_is_inclusive_and_treats_naive_datetimes_as_utc`
- `test_mixed_modality_session_query_returns_text_and_media_records`
- expanded empty-store assertions to cover the new query APIs

### Commands run

```bash
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python tests/test_episodic_store.py
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python -m pytest tests
```

### Results

- episodic store script: all tests passed
- full suite: `37 passed in 3.36s`

## Design Notes

### Why are these direct store methods instead of retriever methods?

Because these operations are not semantic retrieval. They do not ask "what is similar to this query?" They ask:

- "what belongs to this session?"
- "what happened recently?"
- "what happened in this time interval?"

That makes them store-native episodic operations.

### Why load all records and filter in Python?

For the current scope, it keeps the implementation simple, deterministic, and easy to test. The acceptance criteria for this issue are behavior-focused, not optimization-focused.

If the collection becomes large later, these methods can be optimized or backed by more selective querying without changing the public API.

### Why normalize naive datetimes as UTC instead of rejecting them?

Because this repo already creates UTC timestamps by default, and treating naive inputs as UTC gives stable, explicit behavior without surprising test failures. It is also documented directly in the method docstring and the tests.

## Follow-Up

This PR gives the episodic store the direct query primitives needed for the next stages. The natural next steps are:

- expose these through the retriever
- add CLI commands for recent/session/time-range inspection
- build mixed semantic + episodic access patterns on top of them
