### PR TITLE
Wire episodic memory into retriever, CLI, and events for issue #10

### DIFF
--- a/demo/cli.py
+++ b/demo/cli.py
@@ -1,13 +1,24 @@
 import argparse
-import sys
+import mimetypes
 import os
+import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from events import ConsoleLogger, EventBus
+from models.episodic import EpisodicMemory
 from models.semantic import SemanticMemory
+from stores.episodic_store import EpisodicStore
 from stores.semantic_store import SemanticStore
 from retrieval.retriever import UnifiedRetriever
+
+_DEFAULT_MIME_TYPES = {
+    "audio": "audio/mpeg",
+    "image": "image/png",
+    "video": "video/mp4",
+    "pdf": "application/pdf",
+}
 
 
 def _make_bus() -> EventBus:
@@ -16,19 +27,63 @@ def _make_bus() -> EventBus:
     return bus
 
 
+def _make_semantic_store(event_bus: EventBus | None = None) -> SemanticStore:
+    return SemanticStore(event_bus=event_bus)
+
+
+def _make_episodic_store(event_bus: EventBus | None = None) -> EpisodicStore:
+    return EpisodicStore(event_bus=event_bus)
+
+
 def _make_retriever(event_bus: EventBus | None = None) -> UnifiedRetriever:
     return UnifiedRetriever(
-        stores={"semantic": SemanticStore(event_bus=event_bus)},
+        stores={
+            "semantic": _make_semantic_store(event_bus=event_bus),
+            "episodic": _make_episodic_store(event_bus=event_bus),
+        },
         event_bus=event_bus,
     )
 
 
+def _guess_mime_type(path: str, modality: str) -> str:
+    guessed, _ = mimetypes.guess_type(path)
+    return guessed or _DEFAULT_MIME_TYPES[modality]
+
+
+def _default_episode_content(file_path: str, modality: str) -> str:
+    return f"{modality} episode from {Path(file_path).name}"
+
+
 def cmd_store(args):
     bus = _make_bus()
-    store = SemanticStore(event_bus=bus)
+    store = _make_semantic_store(event_bus=bus)
     record = SemanticMemory(content=args.content)
     record_id = store.store(record)
     print(f"Stored [{record_id[:8]}]: {args.content}")
+
+
+def cmd_store_episode(args):
+    bus = _make_bus()
+    store = _make_episodic_store(event_bus=bus)
+
+    if args.text is not None:
+        record = EpisodicMemory(
+            content=args.text,
+            session_id=args.session,
+        )
+    else:
+        media_ref = os.path.abspath(args.file)
+        content = args.content or _default_episode_content(media_ref, args.modality)
+        record = EpisodicMemory(
+            content=content,
+            session_id=args.session,
+            modality=args.modality,
+            media_ref=media_ref,
+            source_mime_type=_guess_mime_type(media_ref, args.modality),
+        )
+
+    record_id = store.store(record)
+    print(f"Stored episode [{record_id[:8]}]: {record.content}")
 
 
 def cmd_query(args):
@@ -48,6 +103,24 @@ def cmd_query(args):
         )
 
 
+def cmd_recent(args):
+    bus = _make_bus()
+    retriever = _make_retriever(event_bus=bus)
+    results = retriever.query_recent(args.n)
+    if not results:
+        print("No recent episodes found.")
+        return
+
+    for rank, record in enumerate(results, 1):
+        age = record.created_at.strftime("%Y-%m-%d %H:%M")
+        media_display = f"  media={record.media_ref}" if record.media_ref else ""
+        print(
+            f"  {rank}. {record.content}\n"
+            f"     type={record.memory_type}  session={record.session_id}  "
+            f"modality={record.modality}  stored={age}  accessed={record.access_count}x{media_display}"
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Agentic Memory CLI")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -59,12 +132,36 @@ def main():
     query_p.add_argument("query", type=str, help="Natural language query")
     query_p.add_argument("-k", "--top-k", type=int, default=5, help="Number of results")
 
+    episode_p = sub.add_parser("store-episode", help="Store a new episodic memory")
+    episode_p.add_argument("--session", required=True, help="Session identifier")
+    episode_src = episode_p.add_mutually_exclusive_group(required=True)
+    episode_src.add_argument("--text", help="Text content for the episode")
+    episode_src.add_argument("--file", help="Path to media file for the episode")
+    episode_p.add_argument(
+        "--modality",
+        choices=["audio", "image", "video", "pdf"],
+        help="Media modality for file-backed episodes",
+    )
+    episode_p.add_argument(
+        "--content",
+        help="Optional human-readable description for file-backed episodes",
+    )
+
+    recent_p = sub.add_parser("recent", help="Show recent episodic memories")
+    recent_p.add_argument("n", type=int, help="Number of recent episodes to show")
+
     args = parser.parse_args()
 
     if args.command == "store":
         cmd_store(args)
     elif args.command == "query":
         cmd_query(args)
+    elif args.command == "store-episode":
+        if args.file and not args.modality:
+            parser.error("--modality is required when using --file")
+        cmd_store_episode(args)
+    elif args.command == "recent":
+        cmd_recent(args)
 
 
 if __name__ == "__main__":

--- a/retrieval/retriever.py
+++ b/retrieval/retriever.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from events.bus import EventBus
+from models.base import MemoryRecord
 from stores.base import BaseStore
 from retrieval.ranking import RankedResult, rank_results
 
@@ -22,6 +23,35 @@ class UnifiedRetriever:
     def _emit_event(self, event_type: str, data: dict[str, Any]) -> None:
         if self._event_bus is not None:
             self._event_bus.emit(event_type, data)
+
+    def _emit_accessed(self, record: MemoryRecord) -> None:
+        payload = {
+            "record_id": record.id,
+            "memory_type": record.memory_type,
+            "access_count": record.access_count,
+            "modality": record.modality,
+        }
+        if record.media_ref:
+            payload["media_ref"] = record.media_ref
+        self._emit_event("memory.accessed", payload)
+
+    def _touch_records(self, records: list[MemoryRecord]) -> list[MemoryRecord]:
+        now = datetime.now(timezone.utc)
+        for record in records:
+            store = self._stores.get(record.memory_type)
+            if store is None:
+                continue
+            store.update_access(record.id)
+            record.access_count += 1
+            record.last_accessed_at = now
+            self._emit_accessed(record)
+        return records
+
+    def _get_episodic_store(self):
+        store = self._stores.get("episodic")
+        if store is None:
+            return None
+        return store
 
     def query(
         self,
@@ -90,21 +120,45 @@ class UnifiedRetriever:
         )
 
         # ── update access tracking on returned records ──────────────────────
-        now = datetime.now(timezone.utc)
-        for r in final:
-            store = self._stores.get(r.record.memory_type)
-            if store:
-                store.update_access(r.record.id)
-                # Keep in-memory record in sync so callers see current values
-                r.record.access_count += 1
-                r.record.last_accessed_at = now
-                self._emit_event(
-                    "memory.accessed",
-                    {
-                        "record_id": r.record.id,
-                        "memory_type": r.record.memory_type,
-                        "access_count": r.record.access_count,
-                    },
-                )
+        self._touch_records([r.record for r in final])
 
         return final
+
+    def query_recent(self, n: int) -> list[MemoryRecord]:
+        store = self._get_episodic_store()
+        records = []
+        if store is not None and hasattr(store, "get_recent"):
+            records = list(store.get_recent(n))
+
+        self._emit_event(
+            "memory.retrieved",
+            {
+                "query": "recent",
+                "query_type": "recent",
+                "memory_types": ["episodic"],
+                "candidate_count": len(records),
+                "top_similarity": None,
+                "limit": n,
+            },
+        )
+        return self._touch_records(records)
+
+    def query_time_range(self, start: datetime, end: datetime) -> list[MemoryRecord]:
+        store = self._get_episodic_store()
+        records = []
+        if store is not None and hasattr(store, "get_by_time_range"):
+            records = list(store.get_by_time_range(start, end))
+
+        self._emit_event(
+            "memory.retrieved",
+            {
+                "query": "time_range",
+                "query_type": "time_range",
+                "memory_types": ["episodic"],
+                "candidate_count": len(records),
+                "top_similarity": None,
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            },
+        )
+        return self._touch_records(records)

--- a/stores/episodic_store.py
+++ b/stores/episodic_store.py
@@ -73,6 +73,7 @@ class EpisodicStore(BaseStore):
                 "modality": record.modality,
                 "importance": record.importance,
                 "session_id": record.session_id,
+                **({"media_ref": record.media_ref} if record.media_ref else {}),
             },
         )
         return record.id

--- a/stores/semantic_store.py
+++ b/stores/semantic_store.py
@@ -44,6 +44,7 @@ class SemanticStore(BaseStore):
                 "content": record.content,
                 "modality": record.modality,
                 "importance": record.importance,
+                **({"media_ref": record.media_ref} if record.media_ref else {}),
             },
         )
         return record.id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,133 @@
+"""Verify CLI episodic commands without provider-backed dependencies."""
+
+import io
+import os
+import sys
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from demo import cli
+from events.bus import EventBus
+from models.episodic import EpisodicMemory
+
+
+class RecordingStore:
+    def __init__(self):
+        self.records = []
+
+    def store(self, record):
+        self.records.append(record)
+        return record.id
+
+
+class FakeRetriever:
+    def __init__(self, recent_records=None):
+        self.recent_records = recent_records or []
+        self.recent_calls = []
+
+    def query_recent(self, n: int):
+        self.recent_calls.append(n)
+        return self.recent_records[:n]
+
+
+def run_cli(argv):
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.object(sys, "argv", argv):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            cli.main()
+    return stdout.getvalue(), stderr.getvalue()
+
+
+def test_store_episode_text_cli_smoke():
+    store = RecordingStore()
+
+    with patch.object(cli, "_make_bus", return_value=EventBus()):
+        with patch.object(cli, "_make_episodic_store", return_value=store):
+            stdout, _ = run_cli(
+                [
+                    "cli",
+                    "store-episode",
+                    "--session",
+                    "session-text",
+                    "--text",
+                    "We resolved an episodic retrieval bug",
+                ]
+            )
+
+    assert "Stored episode [" in stdout
+    assert len(store.records) == 1
+    record = store.records[0]
+    assert isinstance(record, EpisodicMemory)
+    assert record.content == "We resolved an episodic retrieval bug"
+    assert record.session_id == "session-text"
+    assert record.modality == "text"
+    print("  PASS  CLI stores text-backed episodic memories")
+
+
+def test_store_episode_file_cli_smoke():
+    store = RecordingStore()
+    fd, path = tempfile.mkstemp(suffix=".png", prefix="cli_episode_")
+    os.close(fd)
+    with open(path, "wb") as handle:
+        handle.write(b"fake-image")
+
+    try:
+        with patch.object(cli, "_make_bus", return_value=EventBus()):
+            with patch.object(cli, "_make_episodic_store", return_value=store):
+                stdout, _ = run_cli(
+                    [
+                        "cli",
+                        "store-episode",
+                        "--session",
+                        "session-file",
+                        "--file",
+                        path,
+                        "--modality",
+                        "image",
+                        "--content",
+                        "Screenshot from the failed run",
+                    ]
+                )
+
+        assert "Stored episode [" in stdout
+        assert len(store.records) == 1
+        record = store.records[0]
+        assert record.content == "Screenshot from the failed run"
+        assert record.session_id == "session-file"
+        assert record.modality == "image"
+        assert record.media_ref == os.path.abspath(path)
+        assert record.source_mime_type == "image/png"
+        print("  PASS  CLI stores file-backed episodic memories with modality metadata")
+    finally:
+        os.remove(path)
+
+
+def test_recent_cli_smoke():
+    record = EpisodicMemory(
+        content="Most recent episode",
+        session_id="session-recent",
+        created_at=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    retriever = FakeRetriever(recent_records=[record])
+
+    with patch.object(cli, "_make_bus", return_value=EventBus()):
+        with patch.object(cli, "_make_retriever", return_value=retriever):
+            stdout, _ = run_cli(["cli", "recent", "1"])
+
+    assert retriever.recent_calls == [1]
+    assert "Most recent episode" in stdout
+    assert "session=session-recent" in stdout
+    print("  PASS  CLI prints recent episodic memories")
+
+
+if __name__ == "__main__":
+    print("CLI tests:\n")
+    test_store_episode_text_cli_smoke()
+    test_store_episode_file_cli_smoke()
+    test_recent_cli_smoke()
+    print("\nAll tests passed.")

--- a/tests/test_event_integration.py
+++ b/tests/test_event_integration.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import tempfile
 from dataclasses import replace
 from datetime import datetime, timezone, timedelta
 
@@ -9,9 +10,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import config
 from events.bus import EventBus
+from models.episodic import EpisodicMemory
 from models.semantic import SemanticMemory
 from retrieval.retriever import UnifiedRetriever
 from stores.base import BaseStore
+from stores.episodic_store import EpisodicStore
 from stores.semantic_store import SemanticStore
 from tests.helpers import HashingEmbedder, cleanup_dir, make_temp_chroma_dir
 
@@ -24,10 +27,19 @@ class EventRecorder:
 
 
 class FakeStore(BaseStore):
-    def __init__(self, memory_type: str, results: list[tuple[SemanticMemory, float]]):
+    def __init__(
+        self,
+        memory_type: str,
+        results: list[tuple[SemanticMemory, float]],
+        *,
+        recent_records=None,
+        ranged_records=None,
+    ):
         super().__init__()
         self._memory_type = memory_type
         self._results = results
+        self._recent_records = recent_records or []
+        self._ranged_records = ranged_records or []
         self.updated_ids = []
 
     def store(self, record):
@@ -45,6 +57,20 @@ class FakeStore(BaseStore):
 
     def update_access(self, record_id: str) -> None:
         self.updated_ids.append(record_id)
+
+    def get_recent(self, n: int):
+        return self._recent_records[:n]
+
+    def get_by_time_range(self, start, end):
+        return list(self._ranged_records)
+
+
+def make_media_file(suffix: str, data: bytes) -> str:
+    fd, path = tempfile.mkstemp(suffix=suffix, prefix="episodic_event_media_")
+    os.close(fd)
+    with open(path, "wb") as handle:
+        handle.write(data)
+    return path
 
 
 def test_semantic_store_emits_memory_stored():
@@ -101,6 +127,41 @@ def test_semantic_store_does_not_emit_when_write_fails():
     finally:
         config.CHROMA_DB_PATH = original_db_path
         cleanup_dir(db_path)
+
+
+def test_episodic_store_emits_media_context_in_memory_stored():
+    db_path = make_temp_chroma_dir("chroma_test_event_episodic_")
+    media_path = make_media_file(".png", b"episodic-image")
+    original_db_path = config.CHROMA_DB_PATH
+    config.CHROMA_DB_PATH = db_path
+
+    try:
+        bus = EventBus()
+        recorder = EventRecorder(bus, "memory.stored")
+        store = EpisodicStore(event_bus=bus, embedder=HashingEmbedder())
+        record = EpisodicMemory(
+            content="Screenshot of a failed build",
+            session_id="session-media",
+            modality="image",
+            media_ref=media_path,
+            source_mime_type="image/png",
+        )
+
+        store.store(record)
+
+        assert len(recorder.events) == 1
+        event = recorder.events[0]
+        assert event.data["memory_type"] == "episodic"
+        assert event.data["modality"] == "image"
+        assert event.data["media_ref"] == media_path
+        print("  PASS  EpisodicStore emits modality and media_ref for stored media episodes")
+    finally:
+        config.CHROMA_DB_PATH = original_db_path
+        cleanup_dir(db_path)
+        try:
+            os.remove(media_path)
+        except FileNotFoundError:
+            pass
 
 
 def test_retriever_emits_retrieved_ranked_and_accessed():
@@ -189,11 +250,55 @@ def test_retriever_reports_filtered_memory_types():
     print("  PASS  memory_types filter is reflected in memory.retrieved")
 
 
+def test_retriever_temporal_queries_emit_and_access_episodic_context():
+    now = datetime.now(timezone.utc)
+    episode = EpisodicMemory(
+        content="Episode with media context",
+        session_id="session-direct",
+        modality="image",
+        media_ref="/tmp/example.png",
+        created_at=now,
+    )
+
+    episodic_store = FakeStore(
+        "episodic",
+        [],
+        recent_records=[episode],
+        ranged_records=[episode],
+    )
+    bus = EventBus()
+    recorder = EventRecorder(bus, "memory.retrieved", "memory.accessed")
+    retriever = UnifiedRetriever(stores={"episodic": episodic_store}, event_bus=bus)
+
+    recent = retriever.query_recent(1)
+    ranged = retriever.query_time_range(now - timedelta(minutes=1), now + timedelta(minutes=1))
+
+    assert [record.content for record in recent] == ["Episode with media context"]
+    assert [record.content for record in ranged] == ["Episode with media context"]
+    assert [event.event_type for event in recorder.events] == [
+        "memory.retrieved",
+        "memory.accessed",
+        "memory.retrieved",
+        "memory.accessed",
+    ]
+    assert recorder.events[0].data["query_type"] == "recent"
+    assert recorder.events[0].data["memory_types"] == ("episodic",)
+    assert recorder.events[1].data["memory_type"] == "episodic"
+    assert recorder.events[1].data["modality"] == "image"
+    assert recorder.events[1].data["media_ref"] == "/tmp/example.png"
+    assert recorder.events[2].data["query_type"] == "time_range"
+    assert recorder.events[3].data["access_count"] == 2
+    assert episodic_store.updated_ids == [episode.id, episode.id]
+    print("  PASS  direct episodic retriever queries emit retrieval and access context")
+
+
 if __name__ == "__main__":
     print("Event integration tests:\n")
     test_semantic_store_emits_memory_stored()
     test_semantic_store_does_not_emit_when_write_fails()
+    test_episodic_store_emits_media_context_in_memory_stored()
     test_retriever_emits_retrieved_ranked_and_accessed()
     test_retriever_emits_empty_summary_without_access_events()
     test_retriever_reports_filtered_memory_types()
+    test_retriever_temporal_queries_emit_and_access_episodic_context()
     print("\nAll tests passed.")

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -3,12 +3,15 @@
 import sys
 import os
 import tempfile
+from datetime import datetime, timedelta, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import shutil
 import config
+from models.episodic import EpisodicMemory
 from models.semantic import SemanticMemory
+from stores.episodic_store import EpisodicStore
 from stores.semantic_store import SemanticStore
 from retrieval.retriever import UnifiedRetriever
 from tests.helpers import HashingEmbedder
@@ -24,6 +27,17 @@ def fresh_setup():
     store = SemanticStore(embedder=HashingEmbedder())
     retriever = UnifiedRetriever(stores={"semantic": store})
     return store, retriever, db_path
+
+
+def fresh_mixed_setup():
+    db_path = tempfile.mkdtemp(prefix="chroma_test_retriever_mixed_")
+    _DB_PATHS.append(db_path)
+    shutil.rmtree(db_path, ignore_errors=True)
+    config.CHROMA_DB_PATH = db_path
+    semantic_store = SemanticStore(embedder=HashingEmbedder())
+    episodic_store = EpisodicStore(embedder=HashingEmbedder())
+    retriever = UnifiedRetriever(stores={"semantic": semantic_store, "episodic": episodic_store})
+    return semantic_store, episodic_store, retriever, db_path
 
 
 def test_ranked_retrieval():
@@ -106,6 +120,90 @@ def test_over_fetch():
     print(f"  PASS  top_k=1 returns 1 result (reranker had 3 candidates)")
 
 
+def test_mixed_store_retrieval():
+    semantic_store, episodic_store, retriever, _ = fresh_mixed_setup()
+    now = datetime.now(timezone.utc)
+
+    semantic_store.store(
+        SemanticMemory(
+            content="The retrieval engine indexes documents and facts",
+            created_at=now,
+            importance=0.6,
+        )
+    )
+    episodic_store.store(
+        EpisodicMemory(
+            content="We debugged the retrieval engine during a session",
+            session_id="session-1",
+            created_at=now,
+            importance=0.6,
+        )
+    )
+
+    results = retriever.query("retrieval engine", top_k=2)
+
+    assert len(results) == 2
+    assert {result.record.memory_type for result in results} == {"semantic", "episodic"}
+    print("  PASS  mixed retrieval returns semantic and episodic records together")
+
+
+def test_query_recent_and_time_range_return_episodic_only():
+    semantic_store, episodic_store, retriever, _ = fresh_mixed_setup()
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    semantic_store.store(
+        SemanticMemory(
+            content="A semantic fact that should not appear in temporal queries",
+            created_at=base + timedelta(minutes=30),
+        )
+    )
+    episodic_store.store(
+        EpisodicMemory(
+            content="Earlier episode",
+            session_id="session-1",
+            created_at=base,
+        )
+    )
+    episodic_store.store(
+        EpisodicMemory(
+            content="Later episode",
+            session_id="session-2",
+            created_at=base + timedelta(minutes=10),
+        )
+    )
+
+    recent = retriever.query_recent(1)
+    ranged = retriever.query_time_range(base, base + timedelta(minutes=10))
+
+    assert [record.content for record in recent] == ["Later episode"]
+    assert [record.memory_type for record in ranged] == ["episodic", "episodic"]
+    assert [record.content for record in ranged] == ["Earlier episode", "Later episode"]
+    print("  PASS  direct temporal queries return episodic records only")
+
+
+def test_temporal_queries_update_episodic_access_counts():
+    _, episodic_store, retriever, _ = fresh_mixed_setup()
+    record_id = episodic_store.store(
+        EpisodicMemory(
+            content="Access-tracked episode",
+            session_id="session-access",
+            created_at=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    recent = retriever.query_recent(1)
+    ranged = retriever.query_time_range(
+        datetime(2026, 1, 1, 11, 59, tzinfo=timezone.utc),
+        datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+    )
+    persisted = episodic_store.get_by_id(record_id)
+
+    assert recent[0].access_count == 1
+    assert ranged[0].access_count == 2
+    assert persisted.access_count == 2
+    print("  PASS  temporal retriever queries update episodic access tracking")
+
+
 def cleanup():
     for d in _DB_PATHS:
         shutil.rmtree(d, ignore_errors=True)
@@ -119,6 +217,9 @@ if __name__ == "__main__":
         test_access_persists_across_instances()
         test_memory_types_filter()
         test_over_fetch()
+        test_mixed_store_retrieval()
+        test_query_recent_and_time_range_return_episodic_only()
+        test_temporal_queries_update_episodic_access_counts()
         print("\nAll tests passed.")
     finally:
         cleanup()


### PR DESCRIPTION
## Summary

This PR implements Step 4c: it wires multimodal episodic memory into the retriever, CLI, and event flow.

The earlier Step 4 PRs created the episodic model and store, then added session/time-based direct queries. This PR is the first one that makes those capabilities visible to the rest of the system:

- the retriever can now operate over both semantic and episodic memories
- the retriever exposes episodic-only temporal query methods
- the CLI can now store episodic memories from text or files
- the CLI can now inspect recent episodic memories
- event payloads now carry episodic context like `modality` and `media_ref` where relevant

Closes #10

## Why This PR Exists

Before this change, episodic memory existed in storage, but the main entry points of the repo still behaved as if only semantic memory mattered.

That meant:

- `UnifiedRetriever.query()` only saw semantic memories in normal CLI/bootstrap usage
- there was no public retriever API for "recent episodes" or "episodes in a time window"
- there was no CLI path to store an episode
- there was no CLI path to ingest a media-backed episodic record

This PR closes that gap.

## What Changed

### 1. Registered `EpisodicStore` in the retriever/bootstrap path

File: `demo/cli.py`

The CLI now constructs a retriever with both stores:

- `semantic`
- `episodic`

That means ordinary `query` calls can now return mixed semantic + episodic results without any special-case branching in the ranking layer.

### 2. Added `UnifiedRetriever.query_recent(n)`

File: `retrieval/retriever.py`

This method:

- asks the episodic store for recent episodes only
- emits a `memory.retrieved` event with `query_type="recent"`
- updates episodic access tracking just like semantic retrieval does
- emits `memory.accessed` events with episodic context

This is intentionally not ranking-based semantic retrieval. It is a direct episodic query.

### 3. Added `UnifiedRetriever.query_time_range(start, end)`

File: `retrieval/retriever.py`

This method:

- asks the episodic store for episodes inside the requested time window
- emits a `memory.retrieved` event with `query_type="time_range"`
- updates access tracking on returned episodic records
- emits `memory.accessed` events with modality/media context when available

### 4. Refactored retriever access tracking into one shared path

File: `retrieval/retriever.py`

The previous `query()` implementation updated access inline. This PR factors that into shared helpers so:

- ranked semantic/episodic search
- recent episodic queries
- time-range episodic queries

all use the same access update behavior.

That matters because issue #10 explicitly requires access tracking to work for episodic records after retrieval.

### 5. Added CLI command: `store-episode`

File: `demo/cli.py`

This PR adds:

```bash
store-episode --session <id> --text "..."
```

and:

```bash
store-episode --session <id> --file <path> --modality <audio|image|video|pdf> [--content "..."]
```

Behavior:

- text-backed episodes store as `modality="text"`
- file-backed episodes store the absolute `media_ref`
- file-backed episodes guess `source_mime_type` from the file path when possible
- if no explicit `--content` is provided for a file-backed episode, the CLI creates a readable default description like `image episode from screenshot.png`

### 6. Added CLI command: `recent <n>`

File: `demo/cli.py`

This command asks the retriever for episodic recent results and prints:

- content
- memory type
- session id
- modality
- created_at
- access count
- media path when present

### 7. Extended event payloads with episodic media context

Files:

- `stores/episodic_store.py`
- `stores/semantic_store.py`
- `retrieval/retriever.py`

Changes:

- `memory.stored` now includes `media_ref` when present
- `memory.accessed` now includes `modality`
- `memory.accessed` now includes `media_ref` when present

This keeps existing semantic flows backward-compatible because no existing keys were removed. We only add optional context for richer episodic/media cases.

## End-to-End Flow

### Storing a Text Episode

```mermaid
flowchart TD
    A[CLI: store-episode --session X --text ...] --> B[Build EpisodicMemory]
    B --> C[EpisodicStore.store]
    C --> D[Embed content]
    D --> E[Persist in episodic_memories]
    E --> F[Emit memory.stored]
```

### Storing a File-Backed Episode

```mermaid
flowchart TD
    A[CLI: store-episode --file ... --modality image/audio/video/pdf] --> B[Guess MIME type]
    B --> C[Build EpisodicMemory with modality + media_ref]
    C --> D[EpisodicStore.store]
    D --> E[Embed file-backed episode]
    E --> F[Persist in episodic_memories]
    F --> G[Emit memory.stored with media_ref]
```

### Mixed Retrieval

```mermaid
flowchart TD
    A[CLI: query ...] --> B[UnifiedRetriever.query]
    B --> C[Fan out to SemanticStore]
    B --> D[Fan out to EpisodicStore]
    C --> E[Semantic candidates]
    D --> F[Episodic candidates]
    E --> G[Rank together]
    F --> G
    G --> H[Return mixed results]
    H --> I[Update access tracking]
```

### Direct Episodic Queries

```mermaid
flowchart TD
    A[CLI: recent n or app code calls query_time_range] --> B[UnifiedRetriever direct episodic API]
    B --> C[EpisodicStore direct query]
    C --> D[Return episodic records only]
    D --> E[Emit memory.retrieved]
    E --> F[Update access_count]
    F --> G[Emit memory.accessed with modality/media_ref]
```

## Human-Level Behavior

### Mixed retrieval

If the system contains:

- a semantic memory: "The retrieval engine indexes facts"
- an episodic memory: "We debugged the retrieval engine during a session"

then a normal `query("retrieval engine")` can now return both memory types in one ranked result set.

### Recent episodes

If there are multiple sessions and multiple modalities in the episodic store, `recent 3` now shows the latest episodic records regardless of session and regardless of whether they came from text or a file-backed record.

### File-backed CLI storage

If a user runs:

```bash
store-episode --session build-42 --file ./screenshot.png --modality image
```

the CLI creates an episodic record with:

- `session_id="build-42"`
- `modality="image"`
- `media_ref` set to the absolute path
- `source_mime_type="image/png"` when guessed successfully
- a readable default content string if none was supplied

## Files Changed

### `retrieval/retriever.py`

Added:

- `query_recent(n)`
- `query_time_range(start, end)`
- shared access/event helpers

Effect:

- mixed semantic + episodic retrieval now works in the normal retriever path when both stores are registered
- episodic direct queries update access counts and emit retrieval/access events

### `demo/cli.py`

Added:

- episodic store registration in bootstrap
- `store-episode`
- `recent`
- MIME type inference for file-backed episodes

Effect:

- episodic memory is now reachable from the command line, not just internal store code

### `stores/episodic_store.py`

Changed:

- `memory.stored` event payload now includes `media_ref` when present

### `stores/semantic_store.py`

Changed:

- `memory.stored` preserves backward compatibility and now also carries `media_ref` when present

### `tests/test_retriever.py`

Added coverage for:

- mixed semantic + episodic retrieval
- episodic-only temporal retriever queries
- episodic access tracking through direct retriever APIs

### `tests/test_event_integration.py`

Added coverage for:

- episodic `memory.stored` events carrying modality/media context
- direct episodic retriever queries emitting retrieval/access events

### `tests/test_cli.py`

New file.

Added smoke tests for:

- text-backed episodic CLI storage
- file-backed episodic CLI storage
- recent episodic CLI output

## Tests Run

### Targeted runs

```bash
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python tests/test_retriever.py
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python tests/test_event_integration.py
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python tests/test_cli.py
```

### Full suite

```bash
UV_CACHE_DIR=/tmp/uv-cache .venv/bin/python -m pytest tests
```

### Results

- retriever tests: all passed
- event integration tests: all passed
- CLI tests: all passed
- full suite: `45 passed in 5.73s`

## Scope Boundaries

This PR does not implement:

- benchmark runner integration
- live provider capability verification
- a CLI command for time-range inspection
- benchmark-aligned evaluation harnesses

Those are intentionally left for later issues.

## Design Notes

### Why are `query_recent()` and `query_time_range()` retriever methods if they are not semantic search?

Because the retriever is the public memory access surface for the application. These methods still belong there, even though they delegate to direct episodic store queries instead of ranked embedding search.

### Why keep temporal queries episodic-only?

Because semantic memories are not session-local episodes with time-window replay semantics. The acceptance criteria for issue #10 explicitly call for episodic-only temporal query behavior.

### Why add a separate CLI command instead of overloading `store`?

Because semantic and episodic memory have different required fields and different operator intent. Keeping them explicit avoids hidden behavior and makes media-backed episode ingestion much clearer.
