### PR TITLE
Add vector retrieval hooks and retriever path

### DIFF
--- a/retrieval/retriever.py
+++ b/retrieval/retriever.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
+from config import EMBEDDING_DIMENSIONS
 from events.bus import EventBus
 from models.base import MemoryRecord
 from stores.base import BaseStore
@@ -53,6 +54,77 @@ class UnifiedRetriever:
             return None
         return store
 
+    def _resolve_targets(self, memory_types: list[str] | None = None) -> dict[str, BaseStore]:
+        if not memory_types:
+            return self._stores
+        return {key: value for key, value in self._stores.items() if key in memory_types}
+
+    def _emit_ranked(
+        self,
+        *,
+        final: list[RankedResult],
+        relevance_weight: float,
+        recency_weight: float,
+        importance_weight: float,
+        extra_payload: dict[str, Any] | None = None,
+    ) -> None:
+        payload = {
+            "results": [
+                {
+                    "record_id": r.record.id,
+                    "content": r.record.content,
+                    "final_score": r.final_score,
+                    "raw_similarity": r.raw_similarity,
+                    "recency_score": r.recency_score,
+                    "importance_score": r.importance_score,
+                }
+                for r in final
+            ],
+            "weights": {
+                "relevance": relevance_weight,
+                "recency": recency_weight,
+                "importance": importance_weight,
+            },
+        }
+        if extra_payload:
+            payload.update(extra_payload)
+        self._emit_event("memory.ranked", payload)
+
+    def _rank_and_touch(
+        self,
+        *,
+        all_results: list[tuple[MemoryRecord, float]],
+        top_k: int,
+        relevance_weight: float,
+        recency_weight: float,
+        importance_weight: float,
+        ranked_payload: dict[str, Any] | None = None,
+    ) -> list[RankedResult]:
+        ranked = rank_results(
+            all_results,
+            relevance_weight=relevance_weight,
+            recency_weight=recency_weight,
+            importance_weight=importance_weight,
+        )
+
+        final = ranked[:top_k]
+        self._emit_ranked(
+            final=final,
+            relevance_weight=relevance_weight,
+            recency_weight=recency_weight,
+            importance_weight=importance_weight,
+            extra_payload=ranked_payload,
+        )
+
+        self._touch_records([r.record for r in final])
+        return final
+
+    def _validate_vector_dimensions(self, vector: list[float]) -> None:
+        if len(vector) != EMBEDDING_DIMENSIONS:
+            raise ValueError(
+                f"Expected query vector dimension {EMBEDDING_DIMENSIONS}, got {len(vector)}"
+            )
+
     def query(
         self,
         text: str,
@@ -63,9 +135,7 @@ class UnifiedRetriever:
         importance_weight: float = 0.3,
     ) -> list[RankedResult]:
         # ── fan-out: query matching stores ──────────────────────────────────
-        targets = self._stores
-        if memory_types:
-            targets = {k: v for k, v in self._stores.items() if k in memory_types}
+        targets = self._resolve_targets(memory_types)
 
         # Over-fetch so recency/importance can rescue items outside the
         # initial similarity slice.
@@ -86,43 +156,61 @@ class UnifiedRetriever:
             },
         )
 
-        # ── rank across all stores ──────────────────────────────────────────
-        ranked = rank_results(
-            all_results,
+        return self._rank_and_touch(
+            all_results=all_results,
+            top_k=top_k,
             relevance_weight=relevance_weight,
             recency_weight=recency_weight,
             importance_weight=importance_weight,
+            ranked_payload={"query": text},
         )
 
-        final = ranked[:top_k]
+    def query_by_vector(
+        self,
+        vector: list[float],
+        top_k: int = 5,
+        memory_types: list[str] | None = None,
+        relevance_weight: float = 0.4,
+        recency_weight: float = 0.3,
+        importance_weight: float = 0.3,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[RankedResult]:
+        self._validate_vector_dimensions(vector)
 
-        self._emit_event(
-            "memory.ranked",
-            {
-                "query": text,
-                "results": [
-                    {
-                        "record_id": r.record.id,
-                        "content": r.record.content,
-                        "final_score": r.final_score,
-                        "raw_similarity": r.raw_similarity,
-                        "recency_score": r.recency_score,
-                        "importance_score": r.importance_score,
-                    }
-                    for r in final
-                ],
-                "weights": {
-                    "relevance": relevance_weight,
-                    "recency": recency_weight,
-                    "importance": importance_weight,
-                },
-            },
+        targets = self._resolve_targets(memory_types)
+        fetch_k = top_k * CANDIDATE_MULTIPLIER
+        queried_memory_types = list(targets.keys())
+
+        all_results = []
+        for store in targets.values():
+            all_results.extend(store.retrieve_by_vector(vector, top_k=fetch_k))
+
+        retrieved_payload = {
+            "query_type": "vector",
+            "vector_dimensions": len(vector),
+            "memory_types": queried_memory_types,
+            "candidate_count": len(all_results),
+            "top_similarity": max((score for _, score in all_results), default=None),
+        }
+        if metadata:
+            retrieved_payload["query_metadata"] = metadata
+        self._emit_event("memory.retrieved", retrieved_payload)
+
+        ranked_payload = {
+            "query_type": "vector",
+            "vector_dimensions": len(vector),
+        }
+        if metadata:
+            ranked_payload["query_metadata"] = metadata
+
+        return self._rank_and_touch(
+            all_results=all_results,
+            top_k=top_k,
+            relevance_weight=relevance_weight,
+            recency_weight=recency_weight,
+            importance_weight=importance_weight,
+            ranked_payload=ranked_payload,
         )
-
-        # ── update access tracking on returned records ──────────────────────
-        self._touch_records([r.record for r in final])
-
-        return final
 
     def query_recent(self, n: int) -> list[MemoryRecord]:
         store = self._get_episodic_store()

--- a/stores/base.py
+++ b/stores/base.py
@@ -31,6 +31,15 @@ class BaseStore(ABC):
         ...
 
     @abstractmethod
+    def retrieve_by_vector(
+        self,
+        vector: list[float],
+        top_k: int = 5,
+    ) -> list[tuple[MemoryRecord, float]]:
+        """Vector search. Returns (record, similarity_score) pairs, highest first."""
+        ...
+
+    @abstractmethod
     def update_access(self, record_id: str) -> None:
         """Bump access_count and last_accessed_at for a retrieved record."""
         ...

--- a/stores/episodic_store.py
+++ b/stores/episodic_store.py
@@ -100,8 +100,15 @@ class EpisodicStore(BaseStore):
 
     def retrieve(self, query: str, top_k: int = 5) -> list[tuple[EpisodicMemory, float]]:
         query_embedding = self._embedder.embed_query(query)
+        return self.retrieve_by_vector(query_embedding, top_k=top_k)
+
+    def retrieve_by_vector(
+        self,
+        vector: list[float],
+        top_k: int = 5,
+    ) -> list[tuple[EpisodicMemory, float]]:
         result = self._collection.query(
-            query_embeddings=[query_embedding],
+            query_embeddings=[vector],
             n_results=top_k,
             include=["embeddings", "documents", "metadatas", "distances"],
         )

--- a/stores/semantic_store.py
+++ b/stores/semantic_store.py
@@ -78,8 +78,15 @@ class SemanticStore(BaseStore):
 
     def retrieve(self, query: str, top_k: int = 5) -> list[tuple[SemanticMemory, float]]:
         query_embedding = self._embedder.embed_query(query)
+        return self.retrieve_by_vector(query_embedding, top_k=top_k)
+
+    def retrieve_by_vector(
+        self,
+        vector: list[float],
+        top_k: int = 5,
+    ) -> list[tuple[SemanticMemory, float]]:
         result = self._collection.query(
-            query_embeddings=[query_embedding],
+            query_embeddings=[vector],
             n_results=top_k,
             include=["embeddings", "documents", "metadatas", "distances"],
         )

--- a/tests/test_episodic_store.py
+++ b/tests/test_episodic_store.py
@@ -13,7 +13,7 @@ import config
 from events.bus import EventBus
 from models.episodic import EpisodicMemory
 from stores.episodic_store import EpisodicStore, EpisodicStoreError, MediaTooLargeError
-from tests.helpers import HashingEmbedder
+from tests.helpers import DeterministicMultimodalEmbedder, HashingEmbedder
 
 _TEMP_DIRS = []
 
@@ -574,8 +574,28 @@ def test_empty_store():
         datetime(2026, 1, 1, 0, 0),
         datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
     ) == []
+    assert store.retrieve_by_vector([1.0] + [0.0] * 63, top_k=3) == []
     store.update_access("missing")
     print("  PASS  empty store queries return clean empty results across direct query APIs")
+
+
+def test_retrieve_by_vector_supports_audio_embedding_against_text_memory():
+    embedder = DeterministicMultimodalEmbedder()
+    store, _ = fresh_setup(embedder=embedder)
+    audio_path = make_media_file(".mp3", b"standup")
+    record = EpisodicMemory(
+        content="audio mpeg standup project update",
+        session_id="session-audio",
+    )
+
+    store.store(record)
+    query_vector = embedder.embed_audio(audio_path, mime_type="audio/mpeg")
+    results = store.retrieve_by_vector(query_vector, top_k=1)
+
+    assert len(results) == 1
+    assert results[0][0].id == record.id
+    assert isinstance(results[0][1], float)
+    print("  PASS  episodic vector retrieval can match an audio embedding to a text memory")
 
 
 def test_oversized_media_fails_before_read_and_does_not_emit_event():
@@ -656,6 +676,7 @@ if __name__ == "__main__":
         test_retrieval_shape()
         test_access_tracking()
         test_empty_store()
+        test_retrieve_by_vector_supports_audio_embedding_against_text_memory()
         test_oversized_media_fails_before_read_and_does_not_emit_event()
         test_media_provider_errors_are_wrapped_and_do_not_emit_event()
         print("\nAll tests passed.")

--- a/tests/test_event_integration.py
+++ b/tests/test_event_integration.py
@@ -32,12 +32,14 @@ class FakeStore(BaseStore):
         memory_type: str,
         results: list[tuple[SemanticMemory, float]],
         *,
+        vector_results=None,
         recent_records=None,
         ranged_records=None,
     ):
         super().__init__()
         self._memory_type = memory_type
         self._results = results
+        self._vector_results = vector_results if vector_results is not None else results
         self._recent_records = recent_records or []
         self._ranged_records = ranged_records or []
         self.updated_ids = []
@@ -54,6 +56,9 @@ class FakeStore(BaseStore):
 
     def retrieve(self, query: str, top_k: int = 5):
         return self._results[:top_k]
+
+    def retrieve_by_vector(self, vector: list[float], top_k: int = 5):
+        return self._vector_results[:top_k]
 
     def update_access(self, record_id: str) -> None:
         self.updated_ids.append(record_id)
@@ -230,6 +235,72 @@ def test_retriever_emits_empty_summary_without_access_events():
     print("  PASS  empty retrieval emits summary events but no access events")
 
 
+def test_retriever_vector_queries_emit_retrieved_ranked_and_accessed():
+    now = datetime.now(timezone.utc)
+    best = SemanticMemory(
+        content="image png architecture memory",
+        created_at=now - timedelta(minutes=5),
+        importance=0.9,
+    )
+    other = SemanticMemory(
+        content="audio mpeg sprint recap",
+        created_at=now - timedelta(days=5),
+        importance=0.2,
+    )
+
+    semantic_store = FakeStore("semantic", [], vector_results=[(best, 0.92), (other, 0.35)])
+    bus = EventBus()
+    recorder = EventRecorder(bus, "memory.retrieved", "memory.ranked", "memory.accessed")
+    retriever = UnifiedRetriever(stores={"semantic": semantic_store}, event_bus=bus)
+
+    results = retriever.query_by_vector(
+        [1.0] * config.EMBEDDING_DIMENSIONS,
+        top_k=1,
+        metadata={"source_modality": "image"},
+    )
+
+    assert len(results) == 1
+    assert [event.event_type for event in recorder.events] == [
+        "memory.retrieved",
+        "memory.ranked",
+        "memory.accessed",
+    ]
+
+    retrieved_event, ranked_event, accessed_event = recorder.events
+    assert retrieved_event.data["query_type"] == "vector"
+    assert retrieved_event.data["vector_dimensions"] == config.EMBEDDING_DIMENSIONS
+    assert retrieved_event.data["query_metadata"]["source_modality"] == "image"
+    assert retrieved_event.data["memory_types"] == ("semantic",)
+    assert retrieved_event.data["candidate_count"] == 2
+    assert ranked_event.data["query_type"] == "vector"
+    assert ranked_event.data["vector_dimensions"] == config.EMBEDDING_DIMENSIONS
+    assert ranked_event.data["query_metadata"]["source_modality"] == "image"
+    assert ranked_event.data["results"][0]["record_id"] == best.id
+    assert accessed_event.data["record_id"] == best.id
+    assert semantic_store.updated_ids == [best.id]
+    print("  PASS  vector retrieval emits retrieved, ranked, and accessed events")
+
+
+def test_retriever_vector_queries_emit_empty_summary_without_access_events():
+    bus = EventBus()
+    recorder = EventRecorder(bus, "memory.retrieved", "memory.ranked", "memory.accessed")
+    retriever = UnifiedRetriever(stores={"semantic": FakeStore("semantic", [])}, event_bus=bus)
+
+    results = retriever.query_by_vector([1.0] * config.EMBEDDING_DIMENSIONS, top_k=3)
+
+    assert results == []
+    assert [event.event_type for event in recorder.events] == [
+        "memory.retrieved",
+        "memory.ranked",
+    ]
+    assert recorder.events[0].data["query_type"] == "vector"
+    assert recorder.events[0].data["candidate_count"] == 0
+    assert recorder.events[0].data["top_similarity"] is None
+    assert recorder.events[1].data["query_type"] == "vector"
+    assert recorder.events[1].data["results"] == ()
+    print("  PASS  empty vector retrieval emits summary events but no access events")
+
+
 def test_retriever_reports_filtered_memory_types():
     now = datetime.now(timezone.utc)
     semantic_record = SemanticMemory(content="Semantic fact", created_at=now, importance=0.5)
@@ -301,6 +372,8 @@ if __name__ == "__main__":
     test_episodic_store_emits_media_context_in_memory_stored()
     test_retriever_emits_retrieved_ranked_and_accessed()
     test_retriever_emits_empty_summary_without_access_events()
+    test_retriever_vector_queries_emit_retrieved_ranked_and_accessed()
+    test_retriever_vector_queries_emit_empty_summary_without_access_events()
     test_retriever_reports_filtered_memory_types()
     test_retriever_temporal_queries_emit_and_access_episodic_context()
     print("\nAll tests passed.")

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -14,7 +14,7 @@ from models.semantic import SemanticMemory
 from stores.episodic_store import EpisodicStore
 from stores.semantic_store import SemanticStore
 from retrieval.retriever import UnifiedRetriever
-from tests.helpers import HashingEmbedder
+from tests.helpers import DeterministicMultimodalEmbedder, HashingEmbedder
 
 _DB_PATHS = []
 
@@ -38,6 +38,27 @@ def fresh_mixed_setup():
     episodic_store = EpisodicStore(embedder=HashingEmbedder())
     retriever = UnifiedRetriever(stores={"semantic": semantic_store, "episodic": episodic_store})
     return semantic_store, episodic_store, retriever, db_path
+
+
+def fresh_vector_setup():
+    db_path = tempfile.mkdtemp(prefix="chroma_test_retriever_vector_")
+    _DB_PATHS.append(db_path)
+    shutil.rmtree(db_path, ignore_errors=True)
+    config.CHROMA_DB_PATH = db_path
+    embedder = DeterministicMultimodalEmbedder(dimensions=config.EMBEDDING_DIMENSIONS)
+    semantic_store = SemanticStore(embedder=embedder)
+    episodic_store = EpisodicStore(embedder=embedder)
+    retriever = UnifiedRetriever(stores={"semantic": semantic_store, "episodic": episodic_store})
+    return semantic_store, episodic_store, retriever, embedder, db_path
+
+
+def make_media_file(suffix: str, data: bytes) -> str:
+    fd, path = tempfile.mkstemp(suffix=suffix, prefix="retriever_vector_media_")
+    os.close(fd)
+    with open(path, "wb") as handle:
+        handle.write(data)
+    _DB_PATHS.append(path)
+    return path
 
 
 def test_ranked_retrieval():
@@ -204,6 +225,62 @@ def test_temporal_queries_update_episodic_access_counts():
     print("  PASS  temporal retriever queries update episodic access tracking")
 
 
+def test_query_by_vector_reuses_ranking_and_access_tracking():
+    semantic_store, episodic_store, retriever, embedder, _ = fresh_vector_setup()
+    now = datetime.now(timezone.utc)
+
+    semantic_store.store(
+        SemanticMemory(
+            content="image png architecture roadmap",
+            created_at=now - timedelta(minutes=5),
+            importance=0.8,
+        )
+    )
+    episodic_store.store(
+        EpisodicMemory(
+            content="image png architecture standup",
+            session_id="session-vector",
+            created_at=now,
+            importance=0.9,
+        )
+    )
+
+    image_path = make_media_file(".png", b"architecture")
+    vector = embedder.embed_image(image_path, mime_type="image/png")
+    results = retriever.query_by_vector(
+        vector,
+        top_k=2,
+        metadata={"source_modality": "image"},
+    )
+
+    assert len(results) == 2
+    assert {result.record.memory_type for result in results} == {"semantic", "episodic"}
+    for result in results:
+        assert result.record.access_count == 1
+
+    persisted_counts = []
+    for result in results:
+        if result.record.memory_type == "semantic":
+            persisted = semantic_store.get_by_id(result.record.id)
+        else:
+            persisted = episodic_store.get_by_id(result.record.id)
+        assert persisted is not None
+        persisted_counts.append(persisted.access_count)
+    assert sorted(persisted_counts) == [1, 1]
+    print("  PASS  query_by_vector reuses ranking and access tracking across stores")
+
+
+def test_query_by_vector_rejects_wrong_dimensions_before_store_lookup():
+    _, _, retriever, _, _ = fresh_vector_setup()
+
+    try:
+        retriever.query_by_vector([1.0], top_k=1)
+        raise AssertionError("Expected query_by_vector() to reject the wrong dimension")
+    except ValueError as exc:
+        assert str(config.EMBEDDING_DIMENSIONS) in str(exc)
+    print("  PASS  query_by_vector rejects vectors with the wrong dimension")
+
+
 def cleanup():
     for d in _DB_PATHS:
         shutil.rmtree(d, ignore_errors=True)
@@ -220,6 +297,8 @@ if __name__ == "__main__":
         test_mixed_store_retrieval()
         test_query_recent_and_time_range_return_episodic_only()
         test_temporal_queries_update_episodic_access_counts()
+        test_query_by_vector_reuses_ranking_and_access_tracking()
+        test_query_by_vector_rejects_wrong_dimensions_before_store_lookup()
         print("\nAll tests passed.")
     finally:
         cleanup()

--- a/tests/test_semantic_store.py
+++ b/tests/test_semantic_store.py
@@ -13,7 +13,7 @@ import config
 from models.semantic import SemanticMemory
 from stores.media_store import MediaStore
 from stores.semantic_store import SemanticStore
-from tests.helpers import HashingEmbedder
+from tests.helpers import DeterministicMultimodalEmbedder, HashingEmbedder
 
 _TEMP_DIRS = []
 
@@ -221,10 +221,27 @@ def test_semantic_store_cleans_up_owned_media_on_failure():
     print("  PASS  failed semantic writes clean up owned media")
 
 
+def test_retrieve_by_vector_supports_image_embedding_against_text_memory():
+    embedder = DeterministicMultimodalEmbedder()
+    store, _ = fresh_setup(embedder=embedder)
+    image_path = make_media_file(".png", b"diagram")
+    record = SemanticMemory(content="image png diagram architecture memory")
+
+    store.store(record)
+    query_vector = embedder.embed_image(image_path, mime_type="image/png")
+    results = store.retrieve_by_vector(query_vector, top_k=1)
+
+    assert len(results) == 1
+    assert results[0][0].id == record.id
+    assert isinstance(results[0][1], float)
+    print("  PASS  semantic vector retrieval can match an image embedding to a text memory")
+
+
 if __name__ == "__main__":
     print("Semantic store tests:\n")
     test_text_semantic_round_trip_preserves_metadata()
     test_image_semantic_write_copies_media_and_uses_owned_path()
     test_multimodal_semantic_write_stores_one_vector_and_round_trips()
     test_semantic_store_cleans_up_owned_media_on_failure()
+    test_retrieve_by_vector_supports_image_embedding_against_text_memory()
     print("\nAll tests passed.")


### PR DESCRIPTION
## Summary

This PR implements MM-5E by adding a vector-native retrieval path without introducing a second ranking/access/event pipeline.

It adds:

- store-level `retrieve_by_vector(...)` hooks
- `UnifiedRetriever.query_by_vector(...)`
- strict retriever-side dimension validation
- matching over-fetch, reranking, access tracking, and event emission behavior
- tests for cross-modality retrieval, empty collections, vector events, and dimension mismatch failures

## Why

The retriever was text-first. That meant multimodal callers had no clean way to search using a precomputed image/audio/video embedding.

This PR fixes that by making vector search a first-class machine-facing API.

Layman version:

- humans still search with text or media
- the system can now search with vectors directly
- future image/audio/video query features can reuse the same retrieval pipeline instead of building a parallel one

## What Changed

### Store contract

- Added `retrieve_by_vector(vector, top_k=5) -> list[tuple[MemoryRecord, float]]` to `BaseStore`
- Implemented it in:
  - `stores/semantic_store.py`
  - `stores/episodic_store.py`

Both stores now support:
- text query path: embed text, then query by vector
- direct vector path: query Chroma with a supplied vector

### Retriever

Added `UnifiedRetriever.query_by_vector(...)` with:

- `vector: list[float]`
- `top_k`
- `memory_types`
- ranking weights
- optional `metadata`

Behavior is intentionally aligned with `query(...)`:

- validates vector dimensions before store fan-out
- uses the same `top_k * CANDIDATE_MULTIPLIER` over-fetch
- fans out across selected stores
- reuses the same reranker
- updates access counts and `last_accessed_at`
- emits retrieval and ranking events
- does not log raw vector payloads

### Events

Vector retrieval emits the same event pattern as text retrieval:

- `memory.retrieved`
- `memory.ranked`
- `memory.accessed` for returned results

Vector-specific event metadata now includes:

- `query_type = "vector"`
- `vector_dimensions`
- optional `query_metadata`

Raw vectors are intentionally omitted from event payloads.

## Design Notes

### Dimension validation ownership

Validation is owned by the retriever.

That means `query_by_vector(...)` fails early with a clear error if:

- `len(vector) != EMBEDDING_DIMENSIONS`

Stores still rely on Chroma's native validation as a safety net.

### Task-type asymmetry

This PR does not change the existing embedding task-type contract.

Current behavior remains:

- text queries use `RETRIEVAL_QUERY`
- stored text/media vectors use `RETRIEVAL_DOCUMENT`

That is expected here.

`query_by_vector(...)` assumes caller-supplied media vectors are already valid query inputs and does not try to re-wrap them as text-query embeddings.

### Scope boundary

This PR does not retune Chroma HNSW settings.

That is a real retrieval-quality concern, but it affects existing text retrieval too and would likely require separate collection migration/cloning work. It is intentionally left out of MM-5E.

## Flow

```mermaid
flowchart TD
    A[Caller already has embedding] --> B[UnifiedRetriever.query_by_vector]
    B --> C[Validate vector dimensions]
    C --> D[Resolve target stores]
    D --> E[Fetch top_k * 3 candidates per store]
    E --> F[Merge candidate pairs]
    F --> G[Reuse shared reranker]
    G --> H[Emit memory.retrieved]
    H --> I[Emit memory.ranked]
    I --> J[Update access counters]
    J --> K[Emit memory.accessed]
    K --> L[Return ranked results]
```

## Store-Level Behavior

```mermaid
flowchart LR
    A[BaseStore] --> B[retrieve text]
    A --> C[retrieve_by_vector]
    C --> D[SemanticStore]
    C --> E[EpisodicStore]
    D --> F[Chroma query_embeddings]
    E --> F
```

## Event Behavior

```mermaid
flowchart TD
    A[Vector query] --> B[memory.retrieved]
    B --> C[memory.ranked]
    C --> D[memory.accessed for each returned record]

    B --> E[query_type = vector]
    B --> F[vector_dimensions]
    B --> G[candidate_count]
    C --> H[weights]
    C --> I[ranked results]
```

## Files Changed

- `retrieval/retriever.py`
- `stores/base.py`
- `stores/semantic_store.py`
- `stores/episodic_store.py`
- `tests/test_semantic_store.py`
- `tests/test_episodic_store.py`
- `tests/test_event_integration.py`
- `tests/test_retriever.py`

## Easy Review Checkpoints

### 1. Store contract

Check that BaseStore now requires `retrieve_by_vector(...)` and that the return shape matches existing ranking expectations.

Review:
- `stores/base.py`

### 2. Concrete store implementation

Check that semantic and episodic stores both:
- reuse the existing Chroma query pattern
- accept a supplied vector directly
- preserve `(record, similarity)` output shape
- return `[]` cleanly for empty collections

Review:
- `stores/semantic_store.py`
- `stores/episodic_store.py`

### 3. Retriever invariants

Check that `query_by_vector(...)`:
- validates dimensions before fan-out
- uses the same over-fetch multiplier as text queries
- reuses ranking and access tracking
- supports `memory_types` filtering
- carries vector metadata into events without exposing raw vectors

Review:
- `retrieval/retriever.py`

### 4. Event parity

Check that vector retrieval emits:
- `memory.retrieved`
- `memory.ranked`
- `memory.accessed`

And that:
- `query_type = "vector"` is present
- `vector_dimensions` is present
- `query_metadata` is optional
- raw vector payload is absent

Review:
- `tests/test_event_integration.py`

### 5. Cross-modality acceptance

Check the tests proving:
- image embedding -> text semantic memory
- audio embedding -> text episodic memory
- mixed-store vector retrieval still reranks and updates access counts

Review:
- `tests/test_semantic_store.py`
- `tests/test_episodic_store.py`
- `tests/test_retriever.py`

### 6. Failure and edge cases

Check that:
- wrong vector dimensions fail before store lookup
- empty vector retrieval returns clean empty results
- text retrieval behavior remains unchanged

Review:
- `tests/test_retriever.py`
- `tests/test_event_integration.py`
- `tests/test_episodic_store.py`

## Testing

Ran:

```
.venv/bin/python tests/test_semantic_store.py
.venv/bin/python tests/test_episodic_store.py
.venv/bin/python tests/test_event_integration.py
.venv/bin/python tests/test_retriever.py
```

All passed.

## Risks

- Chroma HNSW tuning is still unchanged, so retrieval quality characteristics remain whatever the current collections already provide
- this PR assumes caller-supplied vectors live in the same semantic space as stored vectors
- higher-level media query entrypoints like `query_by_image(...)` are still out of scope

## Follow-ups

Likely next work after this PR:

- MM-5F or equivalent higher-level media query entrypoints
- retrieval-quality follow-up for Chroma HNSW tuning and collection migration strategy
- broader API/CLI surfaces that call `query_by_vector(...)`