### PR TITLE
Add forgetting API, CLI, UI, and integration tests

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -25,6 +25,8 @@ from stores.episodic_store import EpisodicStore, EpisodicStoreError, MediaTooLar
 from stores.media_store import MediaStore
 from stores.procedural_store import ProceduralMatch, ProceduralStore
 from stores.semantic_store import SemanticStore
+from forgetting.contradiction import ContradictionCandidate, ContradictionDetector
+from forgetting.service import ForgettingReport, ForgettingService
 from utils.embeddings import EmbeddingProviderError, GeminiEmbedder, TextEmbedder
 
 DEFAULT_ALLOWED_ORIGINS = [
@@ -280,7 +282,18 @@ def _serialise_procedural_match(match: ProceduralMatch) -> dict[str, Any]:
 class EventRecorder:
     def __init__(self, bus: EventBus, *, max_events: int = 200):
         self._events: deque[dict[str, Any]] = deque(maxlen=max_events)
-        for event_type in ("memory.stored", "memory.retrieved", "memory.ranked", "memory.accessed"):
+        for event_type in (
+            "memory.stored",
+            "memory.retrieved",
+            "memory.ranked",
+            "memory.accessed",
+            "memory.contradiction_flagged",
+            "memory.supersession_resolved",
+            "memory.faded",
+            "memory.forgotten",
+            "forgetting.cycle_completed",
+            "forgetting.cycle_dry_run",
+        ):
             bus.subscribe(event_type, self._record)
 
     def _record(self, event: MemoryEvent) -> None:
@@ -336,6 +349,17 @@ class MemoryAPIService:
             },
             event_bus=self.bus,
         )
+        self.contradiction_detector = ContradictionDetector(
+            self.semantic_store, event_bus=self.bus,
+        )
+        self.forgetting_service = ForgettingService(
+            semantic_store=self.semantic_store,
+            episodic_store=self.episodic_store,
+            procedural_store=self.procedural_store,
+            media_store=self.media_store,
+            event_bus=self.bus,
+            contradiction_detector=self.contradiction_detector,
+        )
         self.events = EventRecorder(self.bus)
 
     def save_upload(self, upload: UploadFile, memory_id: str) -> tuple[str, str]:
@@ -369,6 +393,54 @@ class MemoryAPIService:
             "recent_sessions": sorted({record.session_id for record in recent}),
             "latest_events": self.events.snapshot(10),
         }
+
+
+def _safe_contradiction_lookup(
+    active_service: MemoryAPIService,
+    record: SemanticMemory,
+) -> list[ContradictionCandidate]:
+    try:
+        return active_service.contradiction_detector.find_potential_contradictions(record)
+    except (ValueError, Exception):
+        return []
+
+
+def _serialise_contradiction_candidate(candidate: ContradictionCandidate) -> dict[str, Any]:
+    return {
+        "record": _serialise_record(candidate.record),
+        "similarity": candidate.similarity,
+    }
+
+
+def _serialise_forgetting_report(report: ForgettingReport) -> dict[str, Any]:
+    return {
+        "dry_run": report.dry_run,
+        "scanned": report.scanned,
+        "kept": report.kept,
+        "faded": report.faded,
+        "pruned": report.pruned,
+        "media_deleted": report.media_deleted,
+        "duplicates_flagged": report.duplicates_flagged,
+        "skipped_records": report.skipped_records,
+        "skipped_media": report.skipped_media,
+        "by_type": dict(report.by_type),
+        "decisions": [
+            {
+                "record_id": d.record_id,
+                "memory_type": d.memory_type,
+                "action": d.action,
+                "reason": d.reason,
+                "score": d.score,
+                "media_deleted": d.media_deleted,
+                "executed": d.executed,
+                "record_skip_reason": d.record_skip_reason,
+                "media_skip_reason": d.media_skip_reason,
+                "old_importance": d.old_importance,
+                "new_importance": d.new_importance,
+            }
+            for d in report.decisions
+        ],
+    }
 
 
 def create_app(
@@ -465,7 +537,13 @@ def create_app(
         except Exception:
             _cleanup_owned_media(active_service, record.media_ref)
             raise
-        return {"record": _serialise_record(record)}
+        candidates = _safe_contradiction_lookup(active_service, record)
+        return {
+            "record": _serialise_record(record),
+            "potential_contradictions": [
+                _serialise_contradiction_candidate(c) for c in candidates
+            ],
+        }
 
     @app.post("/api/memories/episodic/text")
     async def create_text_episode(payload: dict[str, Any]) -> dict[str, Any]:
@@ -782,6 +860,35 @@ def create_app(
     async def by_time_range(start: datetime, end: datetime) -> dict[str, Any]:
         records = service().retriever.query_time_range(start, end)
         return {"records": [_serialise_record(record) for record in records]}
+
+    @app.post("/api/forgetting/preview")
+    async def forgetting_preview() -> dict[str, Any]:
+        report = service().forgetting_service.run_cycle(dry_run=True)
+        return _serialise_forgetting_report(report)
+
+    @app.post("/api/forgetting/run")
+    async def forgetting_run() -> dict[str, Any]:
+        report = service().forgetting_service.run_cycle(dry_run=False)
+        return _serialise_forgetting_report(report)
+
+    @app.post("/api/forgetting/resolve")
+    async def forgetting_resolve(payload: dict[str, Any]) -> dict[str, Any]:
+        keep_id = payload.get("keep_id")
+        supersede_id = payload.get("supersede_id")
+        if not keep_id or not supersede_id:
+            raise HTTPException(status_code=400, detail="keep_id and supersede_id are required")
+        try:
+            service().contradiction_detector.resolve_supersession(
+                superseded_id=supersede_id,
+                kept_id=keep_id,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {
+            "superseded_id": supersede_id,
+            "kept_id": keep_id,
+            "status": "resolved",
+        }
 
     return app
 

--- a/demo/cli.py
+++ b/demo/cli.py
@@ -1,8 +1,11 @@
 import argparse
+import json
 import mimetypes
 import os
 import sys
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -305,6 +308,73 @@ def cmd_recent(args):
         )
 
 
+_API_BASE = os.getenv("MEMORY_API_URL", "http://localhost:8000")
+
+
+def _api_post(path: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload or {}).encode()
+    request = Request(
+        f"{_API_BASE}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request) as response:
+            return json.loads(response.read())
+    except HTTPError as exc:
+        body = exc.read().decode()
+        try:
+            detail = json.loads(body).get("detail", body)
+        except (ValueError, KeyError):
+            detail = body
+        _exit_with_error(f"API error ({exc.code}): {detail}")
+    except URLError as exc:
+        _exit_with_error(f"Cannot reach API at {_API_BASE}: {exc.reason}")
+
+
+def cmd_forgetting_preview(_args):
+    report = _api_post("/api/forgetting/preview")
+    print(
+        f"Forgetting preview: scanned={report['scanned']} "
+        f"kept={report['kept']} faded={report['faded']} "
+        f"pruned={report['pruned']} duplicates={report['duplicates_flagged']}"
+    )
+    for decision in report["decisions"]:
+        if decision["action"] == "keep":
+            continue
+        print(
+            f"  {decision['action']:6s}  {decision['memory_type']:12s}  "
+            f"{decision['record_id'][:8]}  reason={decision['reason']}  "
+            f"score={decision['score']:.4f}"
+        )
+
+
+def cmd_forgetting_run(_args):
+    report = _api_post("/api/forgetting/run")
+    print(
+        f"Forgetting cycle: scanned={report['scanned']} "
+        f"kept={report['kept']} faded={report['faded']} "
+        f"pruned={report['pruned']} media_deleted={report['media_deleted']}"
+    )
+    for decision in report["decisions"]:
+        if decision["action"] == "keep":
+            continue
+        executed = "done" if decision["executed"] else "skipped"
+        print(
+            f"  {decision['action']:6s}  {decision['memory_type']:12s}  "
+            f"{decision['record_id'][:8]}  reason={decision['reason']}  [{executed}]"
+        )
+
+
+def cmd_forgetting_resolve(args):
+    result = _api_post(
+        "/api/forgetting/resolve",
+        {"keep_id": args.keep_id, "supersede_id": args.supersede_id},
+    )
+    print(f"Resolved: superseded {result['superseded_id'][:8]} → kept {result['kept_id'][:8]}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Agentic Memory CLI")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -392,6 +462,13 @@ def main():
     recent_p = sub.add_parser("recent", help="Show recent episodic memories")
     recent_p.add_argument("n", type=int, help="Number of recent episodes to show")
 
+    sub.add_parser("forgetting-preview", help="Preview the next forgetting cycle (via API)")
+    sub.add_parser("forgetting-run", help="Run the forgetting cycle (via API)")
+
+    resolve_p = sub.add_parser("forgetting-resolve", help="Confirm a supersession (via API)")
+    resolve_p.add_argument("keep_id", help="ID of the record to keep")
+    resolve_p.add_argument("supersede_id", help="ID of the record to supersede")
+
     args = parser.parse_args()
 
     if args.command == "store":
@@ -427,6 +504,12 @@ def main():
         cmd_best_procedure(args)
     elif args.command == "recent":
         cmd_recent(args)
+    elif args.command == "forgetting-preview":
+        cmd_forgetting_preview(args)
+    elif args.command == "forgetting-run":
+        cmd_forgetting_run(args)
+    elif args.command == "forgetting-resolve":
+        cmd_forgetting_resolve(args)
 
 
 if __name__ == "__main__":

--- a/forgetting/service.py
+++ b/forgetting/service.py
@@ -440,7 +440,7 @@ class ForgettingService:
                         decision.media_skip_reason = "missing_media"
 
                 self._emit_event(
-                    "memory.pruned",
+                    "memory.forgotten",
                     {
                         "record_id": decision.record_id,
                         "memory_type": decision.memory_type,

--- a/tests/test_forgetting_integration.py
+++ b/tests/test_forgetting_integration.py
@@ -1,0 +1,186 @@
+"""Verify forgetting endpoints, contradiction lookup, and full cycle integration."""
+
+import os
+import shutil
+import sys
+import tempfile
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import config
+from api.app import create_app
+from tests.helpers import HashingEmbedder
+
+
+def make_client(*, media_root: str | None = None) -> httpx.AsyncClient:
+    chroma_dir = tempfile.mkdtemp(prefix="memory_forgetting_chroma_")
+    app = create_app(
+        chroma_path=chroma_dir,
+        media_root=media_root,
+        allowed_origins=["http://localhost:3000"],
+        embedder=HashingEmbedder(dimensions=config.EMBEDDING_DIMENSIONS),
+    )
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    client = httpx.AsyncClient(transport=transport, base_url="http://testserver")
+    client.app = app
+    return client
+
+
+@pytest.mark.anyio
+async def test_semantic_store_returns_potential_contradictions():
+    async with make_client() as client:
+        r1 = await client.post(
+            "/api/memories/semantic",
+            json={"content": "The service runs on port 8080"},
+        )
+        assert r1.status_code == 200
+        body1 = r1.json()
+        assert "potential_contradictions" in body1
+        assert isinstance(body1["potential_contradictions"], list)
+
+        r2 = await client.post(
+            "/api/memories/semantic",
+            json={"content": "The service runs on port 9090"},
+        )
+        assert r2.status_code == 200
+        body2 = r2.json()
+        assert "potential_contradictions" in body2
+
+
+@pytest.mark.anyio
+async def test_forgetting_preview_returns_stable_report():
+    async with make_client() as client:
+        await client.post("/api/memories/semantic", json={"content": "Fact alpha"})
+        await client.post("/api/memories/semantic", json={"content": "Fact beta"})
+
+        response = await client.post("/api/forgetting/preview")
+        assert response.status_code == 200
+        report = response.json()
+
+        assert report["dry_run"] is True
+        assert report["scanned"] == 2
+        assert isinstance(report["decisions"], list)
+        assert len(report["decisions"]) == 2
+        assert report["kept"] + report["faded"] + report["pruned"] == report["scanned"]
+
+        for decision in report["decisions"]:
+            assert "record_id" in decision
+            assert "memory_type" in decision
+            assert "action" in decision
+            assert "score" in decision
+
+
+@pytest.mark.anyio
+async def test_forgetting_preview_does_not_mutate():
+    async with make_client() as client:
+        r = await client.post("/api/memories/semantic", json={"content": "Immutable fact"})
+        record_id = r.json()["record"]["id"]
+
+        await client.post("/api/forgetting/preview")
+
+        overview = await client.get("/api/overview")
+        assert overview.json()["semantic_count"] == 1
+
+
+@pytest.mark.anyio
+async def test_forgetting_run_executes_cycle():
+    async with make_client() as client:
+        await client.post("/api/memories/semantic", json={"content": "Will survive"})
+
+        response = await client.post("/api/forgetting/run")
+        assert response.status_code == 200
+        report = response.json()
+
+        assert report["dry_run"] is False
+        assert report["scanned"] >= 1
+        assert isinstance(report["decisions"], list)
+
+
+@pytest.mark.anyio
+async def test_resolve_endpoint_performs_supersession():
+    async with make_client() as client:
+        r_old = await client.post(
+            "/api/memories/semantic",
+            json={"content": "Old deployment region: us-east-1"},
+        )
+        old_id = r_old.json()["record"]["id"]
+
+        r_new = await client.post(
+            "/api/memories/semantic",
+            json={"content": "New deployment region: eu-west-1"},
+        )
+        new_id = r_new.json()["record"]["id"]
+
+        response = await client.post(
+            "/api/forgetting/resolve",
+            json={"keep_id": new_id, "supersede_id": old_id},
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert result["superseded_id"] == old_id
+        assert result["kept_id"] == new_id
+        assert result["status"] == "resolved"
+
+
+@pytest.mark.anyio
+async def test_resolve_endpoint_rejects_missing_ids():
+    async with make_client() as client:
+        response = await client.post(
+            "/api/forgetting/resolve",
+            json={"keep_id": "nonexistent", "supersede_id": "also-nonexistent"},
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_resolve_endpoint_rejects_empty_payload():
+    async with make_client() as client:
+        response = await client.post("/api/forgetting/resolve", json={})
+        assert response.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_forgetting_events_appear_in_event_stream():
+    async with make_client() as client:
+        await client.post("/api/memories/semantic", json={"content": "Event witness"})
+        await client.post("/api/forgetting/preview")
+
+        events_r = await client.get("/api/events?limit=50")
+        event_types = [e["event_type"] for e in events_r.json()["events"]]
+        assert "forgetting.cycle_dry_run" in event_types
+
+
+@pytest.mark.anyio
+async def test_full_cycle_supersede_then_prune():
+    """End-to-end: store two facts, resolve supersession, run cycle, verify pruned."""
+    async with make_client() as client:
+        r_old = await client.post(
+            "/api/memories/semantic",
+            json={"content": "The API key rotates monthly", "importance": 0.3},
+        )
+        old_id = r_old.json()["record"]["id"]
+
+        r_new = await client.post(
+            "/api/memories/semantic",
+            json={"content": "The API key rotates weekly", "importance": 0.8},
+        )
+        new_id = r_new.json()["record"]["id"]
+
+        await client.post(
+            "/api/forgetting/resolve",
+            json={"keep_id": new_id, "supersede_id": old_id},
+        )
+
+        run_r = await client.post("/api/forgetting/run")
+        report = run_r.json()
+        decisions_by_id = {d["record_id"]: d for d in report["decisions"]}
+
+        assert decisions_by_id[old_id]["action"] == "prune"
+        assert decisions_by_id[old_id]["reason"] == "superseded"
+        assert decisions_by_id[new_id]["action"] == "keep"
+
+        overview = await client.get("/api/overview")
+        assert overview.json()["semantic_count"] == 1

--- a/tests/test_forgetting_service.py
+++ b/tests/test_forgetting_service.py
@@ -138,7 +138,7 @@ def test_dry_run_resolves_duplicate_clusters_component_wise(monkeypatch):
     )
 
     bus = EventBus()
-    recorder = EventRecorder(bus, "forgetting.cycle_dry_run", "memory.pruned", "memory.faded")
+    recorder = EventRecorder(bus, "forgetting.cycle_dry_run", "memory.forgotten", "memory.faded")
     service, media_root = _make_service(
         semantic_records=[first, second, third, unrelated],
         duplicate_pairs=[
@@ -278,7 +278,7 @@ def test_real_run_stages_fade_and_prune_then_deletes_owned_media(monkeypatch):
     )
 
     bus = EventBus()
-    recorder = EventRecorder(bus, "memory.faded", "memory.pruned", "forgetting.cycle_completed")
+    recorder = EventRecorder(bus, "memory.faded", "memory.forgotten", "forgetting.cycle_completed")
     service, media_root = _make_service(
         semantic_records=[fade_record],
         episodic_records=[prune_record],
@@ -312,7 +312,7 @@ def test_real_run_stages_fade_and_prune_then_deletes_owned_media(monkeypatch):
         assert report.media_deleted == 1
         assert [event.event_type for event in recorder.events] == [
             "memory.faded",
-            "memory.pruned",
+            "memory.forgotten",
             "forgetting.cycle_completed",
         ]
         assert recorder.events[0].data["record_id"] == "fade-me"

--- a/web/src/components/playground-app.tsx
+++ b/web/src/components/playground-app.tsx
@@ -30,10 +30,15 @@ import {
 } from "lucide-react";
 import {
   checkHealth,
+  type ContradictionCandidate,
   createFileEpisode,
   createProcedure,
   createSemanticMemory,
   createTextEpisode,
+  type ForgettingReport,
+  forgettingPreview,
+  forgettingResolve,
+  forgettingRun,
   getBestProcedures,
   getEvents,
   getOverview,
@@ -56,7 +61,7 @@ import {
 /* ------------------------------------------------------------------ */
 
 type Notice = { tone: "ok" | "error"; text: string } | null;
-type SidebarTab = "store" | "explore";
+type SidebarTab = "store" | "explore" | "forgetting";
 type StoreMode = "semantic" | "text" | "file" | "procedure";
 type ExploreMode = "recent" | "session" | "time";
 type QueryMode = "text" | "image" | "audio" | "best-procedure";
@@ -663,6 +668,12 @@ export function PlaygroundApp() {
   const [exploreRecords, setExploreRecords] = useState<MemoryRecord[]>([]);
   const [exploreLabel, setExploreLabel] = useState("");
 
+  /* ---- forgetting ---- */
+  const [forgettingReport, setForgettingReport] = useState<ForgettingReport | null>(null);
+  const [contradictions, setContradictions] = useState<ContradictionCandidate[]>([]);
+  const [resolveKeepId, setResolveKeepId] = useState("");
+  const [resolveSupersedId, setResolveSupersedId] = useState("");
+
   /* ================================================================ */
   /*  Effects                                                          */
   /* ================================================================ */
@@ -738,7 +749,12 @@ export function PlaygroundApp() {
     );
     if (result) {
       setSemContent("");
-      setNotice({ tone: "ok", text: `Stored semantic memory ${result.record.id.slice(0, 8)}` });
+      const candidates = result.potential_contradictions ?? [];
+      setContradictions(candidates);
+      const suffix = candidates.length
+        ? ` — ${candidates.length} potential contradiction${candidates.length > 1 ? "s" : ""} found`
+        : "";
+      setNotice({ tone: "ok", text: `Stored semantic memory ${result.record.id.slice(0, 8)}${suffix}` });
     }
   }
 
@@ -934,6 +950,46 @@ export function PlaygroundApp() {
     }
   }
 
+  /* ---- forgetting ---- */
+  async function handleForgettingPreview() {
+    const result = await withBusy("Previewing cycle", forgettingPreview);
+    if (result) {
+      setForgettingReport(result);
+      setNotice({
+        tone: "ok",
+        text: `Preview: ${result.faded} fade, ${result.pruned} prune, ${result.kept} keep`,
+      });
+    }
+  }
+
+  async function handleForgettingRun() {
+    const result = await withBusy("Running cycle", forgettingRun);
+    if (result) {
+      setForgettingReport(result);
+      refreshData();
+      setNotice({
+        tone: "ok",
+        text: `Cycle complete: ${result.faded} faded, ${result.pruned} pruned, ${result.media_deleted} media deleted`,
+      });
+    }
+  }
+
+  async function handleResolve(e: FormEvent) {
+    e.preventDefault();
+    if (!resolveKeepId.trim() || !resolveSupersedId.trim()) return;
+    const result = await withBusy("Resolving supersession", () =>
+      forgettingResolve({
+        keep_id: resolveKeepId.trim(),
+        supersede_id: resolveSupersedId.trim(),
+      }),
+    );
+    if (result) {
+      setResolveKeepId("");
+      setResolveSupersedId("");
+      setNotice({ tone: "ok", text: `Superseded ${result.superseded_id.slice(0, 8)} → kept ${result.kept_id.slice(0, 8)}` });
+    }
+  }
+
   /* ================================================================ */
   /*  Render                                                           */
   /* ================================================================ */
@@ -1025,6 +1081,9 @@ export function PlaygroundApp() {
             </TabButton>
             <TabButton active={sidebarTab === "explore"} onClick={() => setSidebarTab("explore")}>
               Explore
+            </TabButton>
+            <TabButton active={sidebarTab === "forgetting"} onClick={() => setSidebarTab("forgetting")}>
+              Forgetting
             </TabButton>
           </div>
 
@@ -1356,6 +1415,128 @@ export function PlaygroundApp() {
                 </form>
               )}
             </>
+          )}
+
+          {/* ---- Forgetting tab ---- */}
+          {sidebarTab === "forgetting" && (
+            <div className="space-y-5 p-5">
+              {/* cycle controls */}
+              <div>
+                <p className="mb-3 text-[11px] font-medium uppercase tracking-wider text-[var(--text-4)]">
+                  Forgetting cycle
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={handleForgettingPreview}
+                    className="flex items-center gap-1.5 rounded-lg bg-white/[0.06] px-3 py-1.5 text-xs font-medium text-[var(--text-2)] transition hover:bg-white/[0.1] disabled:opacity-40"
+                  >
+                    <Search className="size-3" />
+                    Preview
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isBusy}
+                    onClick={handleForgettingRun}
+                    className="flex items-center gap-1.5 rounded-lg bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-300 transition hover:bg-red-500/20 disabled:opacity-40"
+                  >
+                    <Trash2 className="size-3" />
+                    Run cycle
+                  </button>
+                </div>
+              </div>
+
+              {/* resolve */}
+              <form className="space-y-3" onSubmit={handleResolve}>
+                <p className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-4)]">
+                  Resolve supersession
+                </p>
+                <div>
+                  <FormLabel>Keep ID</FormLabel>
+                  <FieldInput
+                    value={resolveKeepId}
+                    onChange={(e) => setResolveKeepId(e.target.value)}
+                    placeholder="ID of the record to keep"
+                  />
+                </div>
+                <div>
+                  <FormLabel>Supersede ID</FormLabel>
+                  <FieldInput
+                    value={resolveSupersedId}
+                    onChange={(e) => setResolveSupersedId(e.target.value)}
+                    placeholder="ID of the record to replace"
+                  />
+                </div>
+                <SubmitButton disabled={isBusy || !resolveKeepId.trim() || !resolveSupersedId.trim()} small>
+                  Resolve
+                </SubmitButton>
+              </form>
+
+              {/* contradiction candidates */}
+              {contradictions.length > 0 && (
+                <div>
+                  <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-[var(--text-4)]">
+                    Recent contradictions
+                  </p>
+                  <div className="space-y-2">
+                    {contradictions.map((c) => (
+                      <div
+                        key={c.record.id}
+                        className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-xs"
+                      >
+                        <p className="text-[var(--text-2)]">{c.record.content}</p>
+                        <p className="mt-1 text-[var(--text-4)]">
+                          similarity {(c.similarity * 100).toFixed(1)}% &middot; {c.record.id.slice(0, 8)}
+                        </p>
+                        <button
+                          type="button"
+                          className="mt-2 rounded bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-300 hover:bg-amber-500/20"
+                          onClick={() => {
+                            setResolveSupersedId(c.record.id);
+                            setNotice({ tone: "ok", text: `Supersede ID set to ${c.record.id.slice(0, 8)}` });
+                          }}
+                        >
+                          Use as superseded
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* report */}
+              {forgettingReport && (
+                <div>
+                  <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-[var(--text-4)]">
+                    {forgettingReport.dry_run ? "Preview report" : "Cycle report"}
+                  </p>
+                  <div className="space-y-1 rounded-lg border border-[var(--border)] bg-[var(--bg-alt)] p-3 text-xs">
+                    <p className="text-[var(--text-2)]">
+                      Scanned {forgettingReport.scanned} &middot; Kept {forgettingReport.kept} &middot;
+                      Faded {forgettingReport.faded} &middot; Pruned {forgettingReport.pruned}
+                    </p>
+                    {forgettingReport.duplicates_flagged > 0 && (
+                      <p className="text-amber-300">
+                        {forgettingReport.duplicates_flagged} duplicate{forgettingReport.duplicates_flagged > 1 ? "s" : ""}
+                      </p>
+                    )}
+                    {forgettingReport.media_deleted > 0 && (
+                      <p className="text-[var(--text-3)]">{forgettingReport.media_deleted} media files deleted</p>
+                    )}
+                    {forgettingReport.decisions
+                      .filter((d) => d.action !== "keep")
+                      .map((d) => (
+                        <p key={d.record_id} className="text-[var(--text-4)]">
+                          {d.action} {d.memory_type} {d.record_id.slice(0, 8)} — {d.reason ?? "decay"}{" "}
+                          ({d.score.toFixed(3)})
+                          {d.record_skip_reason ? ` [${d.record_skip_reason}]` : ""}
+                        </p>
+                      ))}
+                  </div>
+                </div>
+              )}
+            </div>
           )}
         </aside>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -53,6 +53,39 @@ export type ProceduralMatchResult = {
   combined_score: number;
 };
 
+export type ContradictionCandidate = {
+  record: MemoryRecord;
+  similarity: number;
+};
+
+export type ForgettingDecision = {
+  record_id: string;
+  memory_type: string;
+  action: string;
+  reason: string | null;
+  score: number;
+  media_deleted: boolean;
+  executed: boolean;
+  record_skip_reason: string | null;
+  media_skip_reason: string | null;
+  old_importance: number | null;
+  new_importance: number | null;
+};
+
+export type ForgettingReport = {
+  dry_run: boolean;
+  scanned: number;
+  kept: number;
+  faded: number;
+  pruned: number;
+  media_deleted: number;
+  duplicates_flagged: number;
+  skipped_records: number;
+  skipped_media: number;
+  by_type: Record<string, Record<string, number>>;
+  decisions: ForgettingDecision[];
+};
+
 const API_BASE = process.env.NEXT_PUBLIC_MEMORY_API_BASE_URL ?? "http://localhost:8000";
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -90,10 +123,13 @@ export function createSemanticMemory(input: {
   category?: string;
   confidence?: number;
 }) {
-  return request<{ record: MemoryRecord }>("/api/memories/semantic", {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return request<{ record: MemoryRecord; potential_contradictions: ContradictionCandidate[] }>(
+    "/api/memories/semantic",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
 }
 
 export function createTextEpisode(input: {
@@ -206,4 +242,22 @@ export function getSessionEpisodes(sessionId: string) {
 export function getTimeRangeEpisodes(startIso: string, endIso: string) {
   const params = new URLSearchParams({ start: startIso, end: endIso });
   return request<{ records: MemoryRecord[] }>(`/api/episodes/time-range?${params.toString()}`);
+}
+
+export function forgettingPreview() {
+  return request<ForgettingReport>("/api/forgetting/preview", { method: "POST" });
+}
+
+export function forgettingRun() {
+  return request<ForgettingReport>("/api/forgetting/run", { method: "POST" });
+}
+
+export function forgettingResolve(input: { keep_id: string; supersede_id: string }) {
+  return request<{ superseded_id: string; kept_id: string; status: string }>(
+    "/api/forgetting/resolve",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/forgetting/preview`, `POST /api/forgetting/run`, `POST /api/forgetting/resolve` endpoints
- Modify `POST /api/memories/semantic` to always return `potential_contradictions` alongside the stored record
- Add CLI commands (`forgetting-preview`, `forgetting-run`, `forgetting-resolve`) that call the API, not local stores
- Add Forgetting tab to the playground UI with preview/run controls, supersession resolve form, contradiction candidates, and cycle report display
- Wire all forgetting events into the existing `EventRecorder` pipeline
- Rename `memory.pruned` → `memory.forgotten` to match the issue spec

## What changed

### API (`api/app.py`)
- `MemoryAPIService` now constructs `ContradictionDetector` and `ForgettingService`
- `EventRecorder` subscribes to `memory.contradiction_flagged`, `memory.supersession_resolved`, `memory.faded`, `memory.forgotten`, `forgetting.cycle_completed`, `forgetting.cycle_dry_run`
- Semantic store endpoint runs contradiction-candidate lookup after storage and returns `potential_contradictions: []` in every response
- Three new forgetting endpoints with stable report serialisation

### CLI (`demo/cli.py`)
- `forgetting-preview` / `forgetting-run` / `forgetting-resolve` subcommands
- Uses `urllib` to POST to the running API server (`MEMORY_API_URL` env var, default `http://localhost:8000`)
- Does not open a second set of Chroma stores

### UI (`web/`)
- New "Forgetting" sidebar tab with preview/run buttons, resolve form, contradiction display, and report rendering
- `createSemanticMemory` return type updated to include `potential_contradictions`
- Forgetting types and API functions added to `api.ts`

### Event rename
- `memory.pruned` → `memory.forgotten` across service and all tests

## Test plan
- [x] 9 new integration tests covering: contradiction return shape, preview stability, preview immutability, run execution, resolve happy path, resolve 404, resolve 400, event stream, full supersede-then-prune cycle
- [x] All 12 forgetting service unit tests pass
- [x] All 5 contradiction tests pass
- [x] Full suite: 184 passed
- [ ] Manual: start API server, open playground, store two similar semantic facts, verify contradictions appear, preview/run forgetting cycle, resolve a supersession
- [ ] Manual: `python demo/cli.py forgetting-preview` with running server

Closes #45