### PR TITLE
Add GitHub Actions CI for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest anyio pytest-anyio
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ \
+            --ignore=tests/benchmark_memory_system.py \
+            -q --tb=short


### PR DESCRIPTION
## Summary
- Add `.github/workflows/tests.yml` to run the full pytest suite on every PR and push to master
- Excludes `benchmark_memory_system.py` (requires a live server with Gemini API keys)
- Python 3.13, ubuntu-latest

## Test plan
- [x] 184 tests pass locally
- [ ] CI run passes on this PR (self-validating)